### PR TITLE
change: Moved the Offline Alert toggle to the APIClient.

### DIFF
--- a/src/app/components/forms/itemDeleteForm/itemDeleteForm.component.spec.ts
+++ b/src/app/components/forms/itemDeleteForm/itemDeleteForm.component.spec.ts
@@ -249,7 +249,6 @@ describe("Popup", () => {
       of({ success: true, deleted: 4 }),
     );
     const alertsSpy = spyOn(itemDeleteForm["alertsService"], "createSuccessAlert");
-    const toggleSpy = spyOn(itemDeleteForm["alertsService"], "toggleOfflineAlert");
     const swManagerSpy = spyOn(itemDeleteForm["swManager"], "deleteItem");
     itemDeleteForm.toDelete = "Post";
     itemDeleteForm.itemToDelete = 4;
@@ -263,7 +262,6 @@ describe("Popup", () => {
       "Post 4 was deleted. Refresh to view the updated post list.",
       true,
     );
-    expect(toggleSpy).toHaveBeenCalled();
     expect(swManagerSpy).toHaveBeenCalledWith("posts", 4);
   });
 
@@ -274,7 +272,6 @@ describe("Popup", () => {
       of({ success: true, deleted: 4 }),
     );
     const alertsSpy = spyOn(itemDeleteForm["alertsService"], "createSuccessAlert");
-    const toggleSpy = spyOn(itemDeleteForm["alertsService"], "toggleOfflineAlert");
     const swManagerSpy = spyOn(itemDeleteForm["swManager"], "deleteItems");
     itemDeleteForm.toDelete = "Thread";
     itemDeleteForm.itemToDelete = 4;
@@ -288,7 +285,6 @@ describe("Popup", () => {
       "Thread 4 was deleted. Refresh to view the updated thread list.",
       true,
     );
-    expect(toggleSpy).toHaveBeenCalled();
     expect(swManagerSpy).toHaveBeenCalledWith("messages", "threadID", 4);
   });
 
@@ -341,7 +337,6 @@ describe("Popup", () => {
       of({ success: true, userID: 2, deleted: 4 }),
     );
     const alertsSpy = spyOn(itemDeleteForm["alertsService"], "createSuccessAlert");
-    const toggleSpy = spyOn(itemDeleteForm["alertsService"], "toggleOfflineAlert");
     itemDeleteForm.toDelete = "All posts";
     itemDeleteForm.itemToDelete = 2;
 
@@ -354,7 +349,6 @@ describe("Popup", () => {
       "4 posts were deleted. Refresh to view the updated page.",
       true,
     );
-    expect(toggleSpy).toHaveBeenCalled();
   });
 
   // Check that the popup is exited and the item isn't deleted if the user picks 'never mind'

--- a/src/app/components/forms/itemDeleteForm/itemDeleteForm.component.ts
+++ b/src/app/components/forms/itemDeleteForm/itemDeleteForm.component.ts
@@ -137,7 +137,6 @@ export class ItemDeleteForm {
           } list.`,
           true,
         );
-        this.alertsService.toggleOfflineAlert();
 
         // delete the item from idb
         this.swManager.deleteItem(idbStore, response.deleted);
@@ -172,7 +171,6 @@ export class ItemDeleteForm {
     return this.apiClient
       .delete<{ success: boolean; userID: number; deleted: number }>(url, params)
       .pipe(
-        tap(() => this.alertsService.toggleOfflineAlert()),
         tap((response) =>
           this.alertsService.createSuccessAlert(
             `${response.deleted} ${itemType} were deleted. Refresh to view the updated page.`,

--- a/src/app/components/fullList/fullList.component.spec.ts
+++ b/src/app/components/fullList/fullList.component.spec.ts
@@ -50,7 +50,6 @@ import { SinglePost } from "../post/post.component";
 import { Loader } from "../loader/loader.component";
 import { ApiClientService } from "../../services/apiClient.service";
 import { SWManager } from "../../services/sWManager.service";
-import { AlertsService } from "../../services/alerts.service";
 
 const PageOnePosts = [
   {
@@ -183,7 +182,6 @@ describe("FullList", () => {
     // Inject services
     const apiClient = TestBed.inject(ApiClientService);
     const swManager = TestBed.inject(SWManager);
-    const alertsService = TestBed.inject(AlertsService);
     const paramMap = TestBed.inject(ActivatedRoute);
     paramMap.snapshot.url = [{ path: "New" }] as UrlSegment[];
 
@@ -200,14 +198,12 @@ describe("FullList", () => {
     const apiClientSpy = spyOn(apiClient, "get").and.returnValue(of(mockPageOneResponse));
     const updateInterfaceSpy = spyOn(FullList.prototype, "updateInterface");
     const addItemsSpy = spyOn(swManager, "addFetchedItems");
-    const alertsSpy = spyOn(alertsService, "toggleOfflineAlert");
 
     TestBed.createComponent(FullList);
 
     expect(idbSpy).toHaveBeenCalled();
     expect(apiClientSpy).toHaveBeenCalledWith("posts/new", { page: 1 });
     expect(updateInterfaceSpy).toHaveBeenCalledWith(mockPageOneResponse);
-    expect(alertsSpy).toHaveBeenCalled();
     expect(addItemsSpy).toHaveBeenCalledWith("posts", PageOnePosts, "date");
     done();
   });

--- a/src/app/components/fullList/fullList.component.ts
+++ b/src/app/components/fullList/fullList.component.ts
@@ -39,7 +39,6 @@ import { from, map, switchMap, tap } from "rxjs";
 import { FullListType } from "@app/interfaces/types";
 import { Post } from "@app/interfaces/post.interface";
 import { SWManager } from "@app/services/sWManager.service";
-import { AlertsService } from "@app/services/alerts.service";
 import { ApiClientService } from "@app/services/apiClient.service";
 
 interface PostsListResponse {
@@ -67,7 +66,6 @@ export class FullList {
     private route: ActivatedRoute,
     private router: Router,
     private swManager: SWManager,
-    private alertsService: AlertsService,
     private apiClient: ApiClientService,
   ) {
     const urlPath = this.route.snapshot.url[0].path;
@@ -109,7 +107,6 @@ export class FullList {
       )
       .subscribe((data) => {
         this.updateInterface(data);
-        this.alertsService.toggleOfflineAlert();
         this.swManager.addFetchedItems("posts", data.posts, "date");
       });
   }

--- a/src/app/components/mainPage/mainPage.component.spec.ts
+++ b/src/app/components/mainPage/mainPage.component.spec.ts
@@ -50,7 +50,6 @@ import { PopUp } from "../popUp/popUp.component";
 import { SinglePost } from "../post/post.component";
 import { ApiClientService } from "../../services/apiClient.service";
 import { SWManager } from "../../services/sWManager.service";
-import { AlertsService } from "../../services/alerts.service";
 
 const newItems = [
   {
@@ -129,7 +128,6 @@ describe("MainPage", () => {
     // Inject services
     const apiClient = TestBed.inject(ApiClientService);
     const swManager = TestBed.inject(SWManager);
-    const alertsService = TestBed.inject(AlertsService);
 
     // set up mock data
     const mockNetworkResponse = { recent: newItems, suggested: suggestedItems, success: true };
@@ -141,14 +139,12 @@ describe("MainPage", () => {
     const apiClientSpy = spyOn(apiClient, "get").and.returnValue(of(mockNetworkResponse));
     const updateInterfaceSpy = spyOn(MainPage.prototype, "updatePostsInterface");
     const addItemsSpy = spyOn(swManager, "addFetchedItems");
-    const alertsSpy = spyOn(alertsService, "toggleOfflineAlert");
 
     TestBed.createComponent(MainPage);
 
     expect(idbSpy).toHaveBeenCalled();
     expect(apiClientSpy).toHaveBeenCalledWith("");
     expect(updateInterfaceSpy).toHaveBeenCalledWith(mockNetworkResponse);
-    expect(alertsSpy).toHaveBeenCalled();
     expect(addItemsSpy).toHaveBeenCalledWith(
       "posts",
       [...mockNetworkResponse.recent, ...mockNetworkResponse.suggested],

--- a/src/app/components/mainPage/mainPage.component.ts
+++ b/src/app/components/mainPage/mainPage.component.ts
@@ -38,7 +38,6 @@ import { forkJoin, from, map, switchMap, tap } from "rxjs";
 import { ApiClientService } from "@app/services/apiClient.service";
 import { SWManager } from "@app/services/sWManager.service";
 import { Post } from "@app/interfaces/post.interface";
-import { AlertsService } from "@app/services/alerts.service";
 
 interface MainPageResponse {
   recent: Post[];
@@ -61,7 +60,6 @@ export class MainPage {
   constructor(
     private apiClient: ApiClientService,
     private swManager: SWManager,
-    private alertsService: AlertsService,
   ) {
     this.fetchPosts();
   }
@@ -78,7 +76,6 @@ export class MainPage {
       .pipe(switchMap(() => this.apiClient.get<MainPageResponse>("")))
       .subscribe((data) => {
         this.updatePostsInterface(data);
-        this.alertsService.toggleOfflineAlert();
         this.swManager.addFetchedItems("posts", [...data.recent, ...data.suggested], "date");
       });
   }

--- a/src/app/components/messages/messages.component.spec.ts
+++ b/src/app/components/messages/messages.component.spec.ts
@@ -180,7 +180,6 @@ describe("AppMessaging", () => {
     const apiClientSpy = spyOn(appMessaging["apiClient"], "get").and.returnValue(
       of({ messages: mockMessages, total_pages: 2, current_page: 1, success: true }),
     );
-    const toggleSpy = spyOn(appMessaging["alertsService"], "toggleOfflineAlert");
     const swManagerSpy = spyOn(appMessaging["swManager"], "addFetchedItems");
 
     // before
@@ -202,7 +201,6 @@ describe("AppMessaging", () => {
     expect(appMessaging.messages()).toEqual(mockMessages);
     expect(appMessaging.totalPages()).toBe(2);
     expect(appMessaging.currentPage()).toBe(1);
-    expect(toggleSpy).toHaveBeenCalled();
     expect(swManagerSpy).toHaveBeenCalledWith("messages", mockMessages, "date");
   });
 
@@ -289,7 +287,6 @@ describe("AppMessaging", () => {
     const apiClientSpy = spyOn(appMessaging["apiClient"], "get").and.returnValue(
       of({ messages: mockThreads, total_pages: 2, current_page: 1, success: true }),
     );
-    const toggleSpy = spyOn(appMessaging["alertsService"], "toggleOfflineAlert");
     const swManagerSpy = spyOn(appMessaging["swManager"], "addFetchedItems");
 
     // before
@@ -311,7 +308,6 @@ describe("AppMessaging", () => {
     expect(appMessaging.userThreads()).toEqual(mockThreads);
     expect(appMessaging.totalPages()).toBe(2);
     expect(appMessaging.currentPage()).toBe(1);
-    expect(toggleSpy).toHaveBeenCalled();
     expect(swManagerSpy).toHaveBeenCalledWith("threads", mockThreads, "latestMessage");
   });
 

--- a/src/app/components/messages/messages.component.ts
+++ b/src/app/components/messages/messages.component.ts
@@ -43,7 +43,6 @@ import { UserIconColours } from "@app/interfaces/user.interface";
 import { Message } from "@app/interfaces/message.interface";
 import { SWManager } from "@app/services/sWManager.service";
 import { ApiClientService } from "@app/services/apiClient.service";
-import { AlertsService } from "@app/services/alerts.service";
 
 interface MessagesResponse {
   success: boolean;
@@ -110,7 +109,6 @@ export class AppMessaging implements OnInit, AfterViewChecked {
     public router: Router,
     private swManager: SWManager,
     private apiClient: ApiClientService,
-    private alertsService: AlertsService,
   ) {
     let messageType;
     this.threadId = Number(this.route.snapshot.paramMap.get("id"));
@@ -203,7 +201,6 @@ export class AppMessaging implements OnInit, AfterViewChecked {
           this.messages.set(data.messages);
           this.totalPages.set(data.total_pages);
           this.isLoading.set(false);
-          this.alertsService.toggleOfflineAlert();
           this.swManager.addFetchedItems("messages", [...data.messages], "date");
         },
       });
@@ -261,7 +258,6 @@ export class AppMessaging implements OnInit, AfterViewChecked {
           this.userThreads.set(data.messages);
           this.totalPages.set(data.total_pages);
           this.isLoading.set(false);
-          this.alertsService.toggleOfflineAlert();
           this.swManager.addFetchedItems("threads", [...data.messages], "latestMessage");
         },
       });

--- a/src/app/components/myPosts/myPosts.component.spec.ts
+++ b/src/app/components/myPosts/myPosts.component.spec.ts
@@ -189,7 +189,6 @@ describe("MyPosts", () => {
     const apiClientSpy = spyOn(myPosts["apiClient"], "get").and.returnValue(
       of({ page: 1, posts: mockPosts, total_pages: 2, success: true }),
     );
-    const alertsSpy = spyOn(myPosts["alertsService"], "toggleOfflineAlert");
     const swSpy = spyOn(myPosts["swManager"], "addFetchedItems");
 
     // before
@@ -201,7 +200,6 @@ describe("MyPosts", () => {
     // after
     expect(idbSpy).toHaveBeenCalled();
     expect(apiClientSpy).toHaveBeenCalledWith("users/all/1/posts", { page: 1 });
-    expect(alertsSpy).toHaveBeenCalled();
     expect(swSpy).toHaveBeenCalledWith("posts", mockPosts, "date");
     expect(myPosts.totalPages()).toEqual(2);
     expect(myPosts.posts()).toEqual(mockPosts);

--- a/src/app/components/myPosts/myPosts.component.ts
+++ b/src/app/components/myPosts/myPosts.component.ts
@@ -42,7 +42,6 @@ import { AuthService } from "@app/services/auth.service";
 import { ItemsService } from "@app/services/items.service";
 import { SWManager } from "@app/services/sWManager.service";
 import { ApiClientService } from "@app/services/apiClient.service";
-import { AlertsService } from "@app/services/alerts.service";
 
 interface MyPostsResponse {
   page: number;
@@ -90,7 +89,6 @@ export class MyPosts implements OnInit {
     private itemsService: ItemsService,
     private swManager: SWManager,
     private apiClient: ApiClientService,
-    private alertsService: AlertsService,
   ) {
     if (!this.userID) {
       this.userID = this.authService.userData.id!;
@@ -141,7 +139,6 @@ export class MyPosts implements OnInit {
         this.posts.set(data.posts);
         this.isLoading.set(false);
         this.isServerFetchResolved.set(true);
-        this.alertsService.toggleOfflineAlert();
         this.swManager.addFetchedItems("posts", data.posts, "date");
       });
   }

--- a/src/app/components/userPage/userPage.component.spec.ts
+++ b/src/app/components/userPage/userPage.component.spec.ts
@@ -335,14 +335,12 @@ describe("UserPage", () => {
     const apiClientSpy = spyOn(userPage["apiClient"], "get").and.returnValue(
       of({ user: mockUser }),
     );
-    const alertsSpy = spyOn(userPage["alertsService"], "toggleOfflineAlert");
     const addItemSpy = spyOn(userPage["swManager"], "addItem");
 
     userPage.fetchOtherUsersData();
 
     expect(idbSpy).toHaveBeenCalled();
     expect(apiClientSpy).toHaveBeenCalledWith("users/all/1");
-    expect(alertsSpy).toHaveBeenCalled();
     expect(addItemSpy).toHaveBeenCalledWith("users", mockUser);
     expect(userPage.otherUser() as OtherUser).toEqual(mockUser);
     expect(userPage.isServerFetchResolved()).toBeTrue();
@@ -475,7 +473,6 @@ describe("UserPage", () => {
     const hugSpy = spyOn(userPage, "sendHug").and.callThrough();
     const apiClientSpy = spyOn(userPage["apiClient"], "post").and.returnValue(of({}));
     const alertsSpy = spyOn(userPage["alertsService"], "createSuccessAlert");
-    const toggleSpy = spyOn(userPage["alertsService"], "toggleOfflineAlert");
     userPage.otherUser.set({
       id: 1,
       displayName: "shirb",
@@ -519,7 +516,6 @@ describe("UserPage", () => {
       userPageDOM.querySelector("#rHugsElement").querySelectorAll(".pageData")[0].textContent,
     ).toBe("4");
     expect(alertsSpy).toHaveBeenCalledWith("Your hug was sent!", true);
-    expect(toggleSpy).toHaveBeenCalled();
     done();
   });
 

--- a/src/app/components/userPage/userPage.component.ts
+++ b/src/app/components/userPage/userPage.component.ts
@@ -207,7 +207,6 @@ export class UserPage implements OnInit, OnDestroy, AfterViewChecked {
           const user = response.user;
           this.otherUser.set(user);
           this.isServerFetchResolved.set(true);
-          this.alertsService.toggleOfflineAlert();
 
           // adds the user's data to the users store
           this.swManager.addItem("users", user);
@@ -274,7 +273,6 @@ export class UserPage implements OnInit, OnDestroy, AfterViewChecked {
         this.otherUser()!.receivedH += 1;
         this.authService.userData.givenH += 1;
         this.alertsService.createSuccessAlert("Your hug was sent!", true);
-        this.alertsService.toggleOfflineAlert();
       },
     });
   }

--- a/src/app/services/apiClient.service.spec.ts
+++ b/src/app/services/apiClient.service.spec.ts
@@ -231,7 +231,7 @@ describe("APIClient Service", () => {
     });
   });
 
-  it("should not alert when a request fails (offline) as it's likely connected", (done: DoneFn) => {
+  it("should toggle the offline alert when a request fails (offline)", (done: DoneFn) => {
     spyOnProperty(navigator, "onLine").and.returnValue(false);
     const alertSpy = spyOn(apiClientService["alertsService"], "createErrorAlert");
     const sampleErrorData = {
@@ -240,10 +240,12 @@ describe("APIClient Service", () => {
       error: { message: "sample error" },
     };
     const sampleError = new HttpErrorResponse(sampleErrorData);
+    const toggleSpy = spyOn(apiClientService["alertsService"], "toggleOfflineAlert");
 
     apiClientService.handleRequestError(sampleError, of(null)).subscribe({
       error: (error: HttpErrorResponse) => {
         expect(alertSpy).not.toHaveBeenCalled();
+        expect(toggleSpy).toHaveBeenCalled();
         done();
       },
     });

--- a/src/app/services/apiClient.service.spec.ts
+++ b/src/app/services/apiClient.service.spec.ts
@@ -87,9 +87,11 @@ describe("APIClient Service", () => {
     const mockResponse = {
       data: "test",
     };
+    const toggleSpy = spyOn(apiClientService["alertsService"], "toggleOfflineAlert");
 
     apiClientService.get("test").subscribe((res) => {
       expect(res).toEqual(mockResponse);
+      expect(toggleSpy).toHaveBeenCalled();
     });
 
     const req = httpController.expectOne(`${apiClientService["serverUrl"]}/test`);
@@ -117,9 +119,11 @@ describe("APIClient Service", () => {
     const mockResponse = {
       data: "test",
     };
+    const toggleSpy = spyOn(apiClientService["alertsService"], "toggleOfflineAlert");
 
     apiClientService.post("test", {}).subscribe((res) => {
       expect(res).toEqual(mockResponse);
+      expect(toggleSpy).toHaveBeenCalled();
     });
 
     const req = httpController.expectOne(`${apiClientService["serverUrl"]}/test`);
@@ -147,9 +151,11 @@ describe("APIClient Service", () => {
     const mockResponse = {
       data: "test",
     };
+    const toggleSpy = spyOn(apiClientService["alertsService"], "toggleOfflineAlert");
 
     apiClientService.patch("test", {}).subscribe((res) => {
       expect(res).toEqual(mockResponse);
+      expect(toggleSpy).toHaveBeenCalled();
     });
 
     const req = httpController.expectOne(`${apiClientService["serverUrl"]}/test`);
@@ -177,9 +183,11 @@ describe("APIClient Service", () => {
     const mockResponse = {
       data: "test",
     };
+    const toggleSpy = spyOn(apiClientService["alertsService"], "toggleOfflineAlert");
 
     apiClientService.delete("test").subscribe((res) => {
       expect(res).toEqual(mockResponse);
+      expect(toggleSpy).toHaveBeenCalled();
     });
 
     const req = httpController.expectOne(`${apiClientService["serverUrl"]}/test`);
@@ -223,10 +231,9 @@ describe("APIClient Service", () => {
     });
   });
 
-  it("should toggle the offline alert when a request fails (offline)", (done: DoneFn) => {
+  it("should not alert when a request fails (offline) as it's likely connected", (done: DoneFn) => {
     spyOnProperty(navigator, "onLine").and.returnValue(false);
     const alertSpy = spyOn(apiClientService["alertsService"], "createErrorAlert");
-    const toggleSpy = spyOn(apiClientService["alertsService"], "toggleOfflineAlert");
     const sampleErrorData = {
       status: 404,
       statusText: "Not Found",
@@ -237,7 +244,6 @@ describe("APIClient Service", () => {
     apiClientService.handleRequestError(sampleError, of(null)).subscribe({
       error: (error: HttpErrorResponse) => {
         expect(alertSpy).not.toHaveBeenCalled();
-        expect(toggleSpy).toHaveBeenCalled();
         done();
       },
     });

--- a/src/app/services/apiClient.service.ts
+++ b/src/app/services/apiClient.service.ts
@@ -83,6 +83,7 @@ export class ApiClientService {
         params: this.getHttpParams(params || {}),
       })
       .pipe(
+        // if the server is unavilable due to the user being offline, tell the user
         tap((_res) => this.alertsService.toggleOfflineAlert()),
         catchError(this.handleRequestError.bind(this)),
       );
@@ -106,8 +107,9 @@ export class ApiClientService {
         params: this.getHttpParams(params || {}),
       })
       .pipe(
+        // if the server is unavilable due to the user being offline, tell the user
         tap((_res) => this.alertsService.toggleOfflineAlert()),
-        catchError(this.handleRequestError.bind(this))
+        catchError(this.handleRequestError.bind(this)),
       );
   }
 
@@ -129,8 +131,9 @@ export class ApiClientService {
         params: this.getHttpParams(params || {}),
       })
       .pipe(
+        // if the server is unavilable due to the user being offline, tell the user
         tap((_res) => this.alertsService.toggleOfflineAlert()),
-        catchError(this.handleRequestError.bind(this))
+        catchError(this.handleRequestError.bind(this)),
       );
   }
 
@@ -147,8 +150,9 @@ export class ApiClientService {
         params: this.getHttpParams(params || {}),
       })
       .pipe(
+        // if the server is unavilable due to the user being offline, tell the user
         tap((_res) => this.alertsService.toggleOfflineAlert()),
-        catchError(this.handleRequestError.bind(this))
+        catchError(this.handleRequestError.bind(this)),
       );
   }
 
@@ -159,12 +163,8 @@ export class ApiClientService {
    * @returns an observable of the error.
    */
   handleRequestError<T>(error: HttpErrorResponse, _caught: Observable<T>): Observable<T> {
-    // if the server is unavilable due to the user being offline, tell the user
-    if (!navigator.onLine) {
-      this.alertsService.toggleOfflineAlert();
-    }
-    // otherwise just create an error alert
-    else {
+    // If the error isn't that we're offline, create an error alert
+    if (navigator.onLine) {
       this.alertsService.createErrorAlert(error);
     }
 

--- a/src/app/services/apiClient.service.ts
+++ b/src/app/services/apiClient.service.ts
@@ -33,7 +33,7 @@
 // Angular imports
 import { Injectable } from "@angular/core";
 import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from "@angular/common/http";
-import { Observable, catchError, throwError } from "rxjs";
+import { Observable, catchError, tap, throwError } from "rxjs";
 
 // App-related imports
 import { environment } from "@env/environment";
@@ -82,7 +82,10 @@ export class ApiClientService {
         headers: this.authHeader,
         params: this.getHttpParams(params || {}),
       })
-      .pipe(catchError(this.handleRequestError.bind(this)));
+      .pipe(
+        tap((_res) => this.alertsService.toggleOfflineAlert()),
+        catchError(this.handleRequestError.bind(this)),
+      );
   }
 
   /**
@@ -102,7 +105,10 @@ export class ApiClientService {
         headers: this.authHeader,
         params: this.getHttpParams(params || {}),
       })
-      .pipe(catchError(this.handleRequestError.bind(this)));
+      .pipe(
+        tap((_res) => this.alertsService.toggleOfflineAlert()),
+        catchError(this.handleRequestError.bind(this))
+      );
   }
 
   /**
@@ -122,7 +128,10 @@ export class ApiClientService {
         headers: this.authHeader,
         params: this.getHttpParams(params || {}),
       })
-      .pipe(catchError(this.handleRequestError.bind(this)));
+      .pipe(
+        tap((_res) => this.alertsService.toggleOfflineAlert()),
+        catchError(this.handleRequestError.bind(this))
+      );
   }
 
   /**
@@ -137,7 +146,10 @@ export class ApiClientService {
         headers: this.authHeader,
         params: this.getHttpParams(params || {}),
       })
-      .pipe(catchError(this.handleRequestError.bind(this)));
+      .pipe(
+        tap((_res) => this.alertsService.toggleOfflineAlert()),
+        catchError(this.handleRequestError.bind(this))
+      );
   }
 
   /**

--- a/src/app/services/apiClient.service.ts
+++ b/src/app/services/apiClient.service.ts
@@ -163,8 +163,12 @@ export class ApiClientService {
    * @returns an observable of the error.
    */
   handleRequestError<T>(error: HttpErrorResponse, _caught: Observable<T>): Observable<T> {
-    // If the error isn't that we're offline, create an error alert
-    if (navigator.onLine) {
+    // if the server is unavilable due to the user being offline, tell the user
+    if (!navigator.onLine) {
+      this.alertsService.toggleOfflineAlert();
+    }
+    // otherwise just create an error alert
+    else {
       this.alertsService.createErrorAlert(error);
     }
 


### PR DESCRIPTION
Since it's only ever toggled in the context of a network request, it makes more sense to have it in one place rather than repeated throughout the codebaseSince it's only ever toggled in the context of a network request, it makes more sense to have it in one place rather than repeated throughout the codebase.