### PR TITLE
fix: Opening a menu in home page opens it in both 'recent' and 'suggested'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-#### Fixes
+#### Fixes
 
 - Fixed a bug where opening the menu of a post that appears in both the 'recent' and the 'suggested' lists caused the menu to show in both lists, instead of just the list in which the button was clicked ([]()).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+#### Fixes
+
+- Fixed a bug where opening the menu of a post that appears in both the 'recent' and the 'suggested' lists caused the menu to show in both lists, instead of just the list in which the button was clicked ([]()).
+
+### 2024-03-22
+
 #### Chores
 
 - Added a changelog and instructions for writing changelog entries ([#1532](https://github.com/sendahug/send-hug-frontend/pull/1532)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Fixes
 
-- Fixed a bug where opening the menu of a post that appears in both the 'recent' and the 'suggested' lists caused the menu to show in both lists, instead of just the list in which the button was clicked ([]()).
+- Fixed a bug where opening the menu of a post that appears in both the 'recent' and the 'suggested' lists caused the menu to show in both lists, instead of just the list in which the button was clicked ([#1556](https://github.com/sendahug/send-hug-frontend/pull/1556)).
 
 ### 2024-03-22
 

--- a/src/app/components/post/post.component.spec.ts
+++ b/src/app/components/post/post.component.spec.ts
@@ -261,11 +261,11 @@ describe("Post", () => {
     const upFixture = TestBed.createComponent(MockPage);
     upFixture.detectChanges();
     const myPosts = upFixture.debugElement.children[0].componentInstance;
-    myPosts.itemsService.currentlyOpenMenu.next(3);
+    myPosts.itemsService.currentlyOpenMenu.next("nPost3");
     const openMenuSpy = spyOn(myPosts.itemsService.currentlyOpenMenu, "next").and.callThrough();
 
     // before the change
-    expect(myPosts.itemsService.currentlyOpenMenu.value).toBe(3);
+    expect(myPosts.itemsService.currentlyOpenMenu.value).toBe("nPost3");
     expect(openMenuSpy).not.toHaveBeenCalled();
 
     // trigger the function
@@ -273,19 +273,19 @@ describe("Post", () => {
     upFixture.detectChanges();
 
     // after the change
-    expect(myPosts.itemsService.currentlyOpenMenu.value).toBe(1);
-    expect(openMenuSpy).toHaveBeenCalledWith(1);
+    expect(myPosts.itemsService.currentlyOpenMenu.value).toBe("nPost1");
+    expect(openMenuSpy).toHaveBeenCalledWith("nPost1");
   });
 
-  it("toggleMenu() - should set the currently open menu to -1 if the given post's id is already open", () => {
+  it("toggleMenu() - should set the currently open menu to an emptpy string if the given post's id is already open", () => {
     const upFixture = TestBed.createComponent(MockPage);
     upFixture.detectChanges();
     const myPosts = upFixture.debugElement.children[0].componentInstance;
-    myPosts.itemsService.currentlyOpenMenu.next(1);
+    myPosts.itemsService.currentlyOpenMenu.next("nPost1");
     const openMenuSpy = spyOn(myPosts.itemsService.currentlyOpenMenu, "next").and.callThrough();
 
     // before the call
-    expect(myPosts.itemsService.currentlyOpenMenu.value).toBe(1);
+    expect(myPosts.itemsService.currentlyOpenMenu.value).toBe("nPost1");
     expect(openMenuSpy).not.toHaveBeenCalled();
 
     // trigger the function
@@ -293,8 +293,8 @@ describe("Post", () => {
     upFixture.detectChanges();
 
     // after the call
-    expect(myPosts.itemsService.currentlyOpenMenu.value).toBe(-1);
-    expect(openMenuSpy).toHaveBeenCalledWith(-1);
+    expect(myPosts.itemsService.currentlyOpenMenu.value).toBe("");
+    expect(openMenuSpy).toHaveBeenCalledWith("");
   });
 
   // check the posts' menu isn't shown if there isn't enough room for it

--- a/src/app/components/post/post.component.ts
+++ b/src/app/components/post/post.component.ts
@@ -164,7 +164,7 @@ export class SinglePost implements AfterViewChecked, OnInit, OnDestroy {
     if (buttonsContainer.offsetWidth < buttonsWidth) {
       this.shouldMenuFloat.set(true);
 
-      if (this.itemsService.currentlyOpenMenu.value != this.post?.id) {
+      if (this.itemsService.currentlyOpenMenu.value != this.postId()) {
         this.shouldShowSubmenu.set(false);
       } else {
         this.shouldShowSubmenu.set(true);
@@ -261,10 +261,10 @@ export class SinglePost implements AfterViewChecked, OnInit, OnDestroy {
   Programmer: Shir Bar Lev.
   */
   toggleOptions() {
-    if (this.itemsService.currentlyOpenMenu.value !== this.post.id) {
-      this.itemsService.currentlyOpenMenu.next(this.post.id as number);
+    if (this.itemsService.currentlyOpenMenu.value !== this.postId()) {
+      this.itemsService.currentlyOpenMenu.next(this.postId());
     } else {
-      this.itemsService.currentlyOpenMenu.next(-1);
+      this.itemsService.currentlyOpenMenu.next("");
     }
   }
 

--- a/src/app/services/items.service.ts
+++ b/src/app/services/items.service.ts
@@ -68,7 +68,7 @@ export class ItemsService {
   }));
   // Posts variables
   isUpdated = new BehaviorSubject(false);
-  currentlyOpenMenu = new BehaviorSubject(-1);
+  currentlyOpenMenu = new BehaviorSubject("");
   receivedAHug = new BehaviorSubject(0);
 
   // CTOR


### PR DESCRIPTION
**Description**
Opening the menu of a post that appears in both the 'recent' and the 'suggested' lists caused the menu to show in both lists.

**Issue link**


**Expected behavior**
It should be opened just the list in which the button was clicked

**Your solution**
Replaced the numeric "open post" with the calculated ID of the post, which includes the type of post (new/suggested).

**Additional information**
