### PR TITLE
fix: Added missing userVisibleOnly key to push permission check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### 2024-03-25
+
 #### Fixes
 
 - Fixed a bug where opening the menu of a post that appears in both the 'recent' and the 'suggested' lists caused the menu to show in both lists, instead of just the list in which the button was clicked ([#1556](https://github.com/sendahug/send-hug-frontend/pull/1556)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Fixes
 
 - Fixed a bug where opening the menu of a post that appears in both the 'recent' and the 'suggested' lists caused the menu to show in both lists, instead of just the list in which the button was clicked ([#1556](https://github.com/sendahug/send-hug-frontend/pull/1556)).
+- Fixed a bug where requesting permission to send push notifications failed due to a missing key (`userVisibleOnly`) in the object passed to the permission-checking function ([#1557](https://github.com/sendahug/send-hug-frontend/pull/1556)).
 
 ### 2024-03-22
 

--- a/src/app/services/notifications.service.ts
+++ b/src/app/services/notifications.service.ts
@@ -95,7 +95,10 @@ export class NotificationService {
       if ("PushManager" in window && this.serviceWorkerM.activeServiceWorkerReg) {
         // check the state of the Push permission
         this.serviceWorkerM.activeServiceWorkerReg.pushManager
-          .permissionState({})
+          .permissionState({
+            applicationServerKey: this.publicKey as string,
+            userVisibleOnly: true,
+          })
           .then((permission) => {
             // If permission was denied and the user's Push status is true, alert the
             // user they can't get push notifications in this browser
@@ -231,7 +234,10 @@ export class NotificationService {
     if ("PushManager" in window) {
       // check the state of the Push permission
       this.serviceWorkerM.activeServiceWorkerReg?.pushManager
-        .permissionState({})
+        .permissionState({
+          applicationServerKey: this.publicKey as string,
+          userVisibleOnly: true,
+        })
         .then((permission) => {
           // If permission was denied, alert the user they can't get push notifications in this browser
           if (permission == "denied") {


### PR DESCRIPTION
**Description**
The check for whether the user granted permission for sending push notifications raised an error alerting that push subscriptions that don't enable `userVisibleOnly` aren't supported. This prevented us from sending push notifications as the "do we have permission" check was the one that errored, which meant we couldn't request permission and actually send the notifications.

**Issue link**


**Expected behavior**
Permissions check should return `granted`, `prompt` or `denied`.

**Your solution**
Added the missing key to the `permissionState` call.

**Additional information**
