### PR TITLE
chore: Replaced unit tests' RouterTestingModule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Chores
 
-- Deleted the unnecessary heading section from the pull request template ([#1558](https://github.com/sendahug/send-hug-frontend/pull/1558)).
+- Replaced the deprecated Router Testing Module in unit tests with the regular Router Module, as per Angular's guidance ([#1567](https://github.com/sendahug/send-hug-frontend/pull/1567)).
 
 ### 2024-03-30
 
@@ -20,6 +20,7 @@
 
 - Upgraded Gulp from v4 to v5! ([#1563](https://github.com/sendahug/send-hug-frontend/pull/1563))
 - Updated the CircleCI workflow to use the CircleCI Python + Node image instead of the custom image we've been using. The custom image was required when we needed Python, Node and browser tools (as CircleCI only has combinations of two of those, rather than all three), but since we moved to using Cypress in e2e tests (with the Cypress orb), we no longer need to manually install browser tools (the orb does that for us). Now that we only need Node + Python, we can simply use the CircleCI image, as it's cleaner to let CircleCI manage the docker images instead of updating them manually ([#1563](https://github.com/sendahug/send-hug-frontend/pull/1563)).
+- Deleted the unnecessary heading section from the pull request template ([#1558](https://github.com/sendahug/send-hug-frontend/pull/1558)).
 
 ### 2024-03-29
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -30,7 +30,7 @@
   SOFTWARE.
 */
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
@@ -59,7 +59,7 @@ describe("AppComponent", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ReactiveFormsModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),

--- a/src/app/components/aboutApp/aboutApp.component.spec.ts
+++ b/src/app/components/aboutApp/aboutApp.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -52,7 +52,7 @@ describe("AboutApp", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/adminBlocks/adminBlocks.component.spec.ts
+++ b/src/app/components/adminBlocks/adminBlocks.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -76,7 +76,7 @@ describe("Blocks Page", () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/adminDashboard/adminDashboard.component.spec.ts
+++ b/src/app/components/adminDashboard/adminDashboard.component.spec.ts
@@ -31,7 +31,6 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -42,7 +41,7 @@ import { HttpClientModule } from "@angular/common/http";
 import { ServiceWorkerModule } from "@angular/service-worker";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
-import { ActivatedRoute, UrlSegment } from "@angular/router";
+import { ActivatedRoute, RouterModule, UrlSegment } from "@angular/router";
 import { of } from "rxjs";
 
 import { AdminDashboard } from "./adminDashboard.component";
@@ -61,7 +60,7 @@ describe("AdminDashboard", () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/adminFilters/adminFilters.component.spec.ts
+++ b/src/app/components/adminFilters/adminFilters.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -72,7 +72,7 @@ describe("Filters Page", () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/adminReports/adminReports.component.spec.ts
+++ b/src/app/components/adminReports/adminReports.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -90,7 +90,7 @@ describe("AdminReports", () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/appAlert/appAlert.component.spec.ts
+++ b/src/app/components/appAlert/appAlert.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -53,7 +53,7 @@ describe("AppAlert", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/errorPage/errorPage.component.spec.ts
+++ b/src/app/components/errorPage/errorPage.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -53,7 +53,7 @@ describe("ErrorPage", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/forms/displayNameEditForm/displayNameEditForm.component.spec.ts
+++ b/src/app/components/forms/displayNameEditForm/displayNameEditForm.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -58,7 +58,7 @@ describe("DisplayNameEditForm", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/forms/itemDeleteForm/itemDeleteForm.component.spec.ts
+++ b/src/app/components/forms/itemDeleteForm/itemDeleteForm.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -53,7 +53,7 @@ describe("Popup", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/forms/postEditForm/postEditForm.component.spec.ts
+++ b/src/app/components/forms/postEditForm/postEditForm.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -57,7 +57,7 @@ describe("PostEditForm", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/forms/reportForm/reportForm.component.spec.ts
+++ b/src/app/components/forms/reportForm/reportForm.component.spec.ts
@@ -25,7 +25,7 @@
   SOFTWARE.
 */
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -51,7 +51,7 @@ describe("Report", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/fullList/fullList.component.spec.ts
+++ b/src/app/components/fullList/fullList.component.spec.ts
@@ -31,7 +31,6 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -42,7 +41,7 @@ import { HttpClientModule } from "@angular/common/http";
 import { ServiceWorkerModule } from "@angular/service-worker";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import { of } from "rxjs";
-import { ActivatedRoute, Router, UrlSegment } from "@angular/router";
+import { ActivatedRoute, Router, RouterModule, UrlSegment } from "@angular/router";
 
 import { FullList } from "./fullList.component";
 import { PopUp } from "../popUp/popUp.component";
@@ -91,7 +90,7 @@ describe("FullList", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/headerMessage/headerMessage.component.spec.ts
+++ b/src/app/components/headerMessage/headerMessage.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -52,7 +52,7 @@ describe("HeaderMessage", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/iconEditor/iconEditor.component.spec.ts
+++ b/src/app/components/iconEditor/iconEditor.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -55,7 +55,7 @@ describe("IconEditor", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/loader/loader.component.spec.ts
+++ b/src/app/components/loader/loader.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -54,7 +54,7 @@ describe("Loader", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/mainPage/mainPage.component.spec.ts
+++ b/src/app/components/mainPage/mainPage.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -100,7 +100,7 @@ describe("MainPage", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/messages/messages.component.spec.ts
+++ b/src/app/components/messages/messages.component.spec.ts
@@ -31,7 +31,6 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -40,7 +39,7 @@ import {
 } from "@angular/platform-browser-dynamic/testing";
 import { HttpClientModule } from "@angular/common/http";
 import { ServiceWorkerModule } from "@angular/service-worker";
-import { ActivatedRoute, UrlSegment } from "@angular/router";
+import { ActivatedRoute, RouterModule, UrlSegment } from "@angular/router";
 import { of } from "rxjs";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import { By } from "@angular/platform-browser";
@@ -121,7 +120,7 @@ describe("AppMessaging", () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/myPosts/myPosts.component.spec.ts
+++ b/src/app/components/myPosts/myPosts.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -105,7 +105,7 @@ describe("MyPosts", () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/newItem/newItem.component.spec.ts
+++ b/src/app/components/newItem/newItem.component.spec.ts
@@ -31,7 +31,6 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -42,7 +41,7 @@ import { HttpClientModule } from "@angular/common/http";
 import { ServiceWorkerModule } from "@angular/service-worker";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import { of } from "rxjs";
-import { ActivatedRoute, UrlSegment } from "@angular/router";
+import { ActivatedRoute, RouterModule, UrlSegment } from "@angular/router";
 
 import { NewItem } from "./newItem.component";
 import { AuthService } from "../../services/auth.service";
@@ -56,7 +55,7 @@ describe("NewItem", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/notifications/notifications.component.spec.ts
+++ b/src/app/components/notifications/notifications.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -57,7 +57,7 @@ describe("Notifications", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/popUp/popUp.component.spec.ts
+++ b/src/app/components/popUp/popUp.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -59,7 +59,7 @@ describe("Popup", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/post/post.component.spec.ts
+++ b/src/app/components/post/post.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -85,7 +85,7 @@ describe("Post", () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/searchResults/searchResults.component.spec.ts
+++ b/src/app/components/searchResults/searchResults.component.spec.ts
@@ -31,7 +31,6 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -40,7 +39,7 @@ import {
 } from "@angular/platform-browser-dynamic/testing";
 import { HttpClientModule } from "@angular/common/http";
 import { ServiceWorkerModule } from "@angular/service-worker";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, Router, RouterModule } from "@angular/router";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 
 import { SearchResults } from "./searchResults.component";
@@ -111,7 +110,7 @@ describe("SearchResults", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,
@@ -200,7 +199,7 @@ describe("SearchResults", () => {
 
       TestBed.configureTestingModule({
         imports: [
-          RouterTestingModule,
+          RouterModule.forRoot([]),
           HttpClientModule,
           ServiceWorkerModule.register("sw.js", { enabled: false }),
           FontAwesomeModule,
@@ -279,7 +278,7 @@ describe("SearchResults", () => {
 
       TestBed.configureTestingModule({
         imports: [
-          RouterTestingModule,
+          RouterModule.forRoot([]),
           HttpClientModule,
           ServiceWorkerModule.register("sw.js", { enabled: false }),
           FontAwesomeModule,

--- a/src/app/components/settings/settings.component.spec.ts
+++ b/src/app/components/settings/settings.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -60,7 +60,7 @@ describe("SettingsPage", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/siteMap/siteMap.component.spec.ts
+++ b/src/app/components/siteMap/siteMap.component.spec.ts
@@ -31,7 +31,6 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -42,7 +41,7 @@ import { HttpClientModule } from "@angular/common/http";
 import { ServiceWorkerModule } from "@angular/service-worker";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import { Component } from "@angular/core";
-import { Route, Routes } from "@angular/router";
+import { Route, RouterModule, Routes } from "@angular/router";
 
 import { AppComponent } from "../../app.component";
 import { SiteMap } from "./siteMap.component";
@@ -118,7 +117,7 @@ describe("SiteMap", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule.withRoutes(routes),
+        RouterModule.forRoot(routes),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/sitePolicies/sitePolicies.component.spec.ts
+++ b/src/app/components/sitePolicies/sitePolicies.component.spec.ts
@@ -31,7 +31,6 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -41,7 +40,7 @@ import {
 import { HttpClientModule } from "@angular/common/http";
 import { ServiceWorkerModule } from "@angular/service-worker";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
-import { ActivatedRoute, UrlSegment } from "@angular/router";
+import { ActivatedRoute, RouterModule, UrlSegment } from "@angular/router";
 import { of } from "rxjs";
 
 import { SitePolicies } from "./sitePolicies.component";
@@ -54,7 +53,7 @@ describe("SitePolicies", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/supportPage/supportPage.component.spec.ts
+++ b/src/app/components/supportPage/supportPage.component.spec.ts
@@ -31,7 +31,7 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
+import { RouterModule } from "@angular/router";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -53,7 +53,7 @@ describe("Support Page", () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/components/userPage/userPage.component.spec.ts
+++ b/src/app/components/userPage/userPage.component.spec.ts
@@ -31,7 +31,6 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
 import {} from "jasmine";
 import { APP_BASE_HREF } from "@angular/common";
 import {
@@ -40,7 +39,7 @@ import {
 } from "@angular/platform-browser-dynamic/testing";
 import { HttpClientModule } from "@angular/common/http";
 import { ServiceWorkerModule } from "@angular/service-worker";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, RouterModule } from "@angular/router";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import { By } from "@angular/platform-browser";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
@@ -62,7 +61,7 @@ describe("UserPage", () => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,

--- a/src/app/services/alerts.service.spec.ts
+++ b/src/app/services/alerts.service.spec.ts
@@ -31,7 +31,6 @@
 */
 
 import { TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
@@ -51,7 +50,7 @@ describe("AlertsService", () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [],
       declarations: [],
       providers: [AlertsService, { provide: APP_BASE_HREF, useValue: "/" }],
     }).compileComponents();


### PR DESCRIPTION
**Description**

The RouterTestingModule provided by the Angular router is apparently deprecated. We're still using it in all tests.

**Issue link**

None.

**Expected behavior**

None.

**Your solution**

Replaced the RouterTestingModule, which is apparently deprecated, with the regular RouterModule. 

**Additional information**

None.