### PR TITLE
fix: New message's for value is [object object]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+#### Fixes
+
+- Fixed a bug where the "new messages" screen accidentally showed `[object object]` instead of the name of the user to send a message to in the "for" field when users tried to send a new message from the messages' views ([#1569](https://github.com/sendahug/send-hug-frontend/pull/1569)).
+
+### 2024-03-31
+
 #### Chores
 
 - Replaced the deprecated Router Testing Module in unit tests with the regular Router Module, as per Angular's guidance ([#1567](https://github.com/sendahug/send-hug-frontend/pull/1567)).

--- a/src/app/components/messages/messages.component.html
+++ b/src/app/components/messages/messages.component.html
@@ -45,7 +45,7 @@
 					<span class="pageData">For</span><span class="pageData" aria-describedby="mUserFor">{{ message.for.displayName }}</span>
 				</div>
 				<div class="buttons">
-					<a [routerLink]="['/new', 'Message']" [queryParams]="{user: message.from, userID: message.fromId}" class="appButton messageButton" [attr.aria-describedby]="'mReply ' +  'text' + message.id" *ngIf="messType == 'inbox'">Reply</a>
+					<a [routerLink]="['/new', 'Message']" [queryParams]="{user: message.from.displayName, userID: message.fromId}" class="appButton messageButton" [attr.aria-describedby]="'mReply ' +  'text' + message.id" *ngIf="messType == 'inbox'">Reply</a>
 					<button class="appButton deleteButton" (click)="deleteMessage(message.id)" [attr.aria-describedby]="'mDelete ' + text + message.id">Delete Message</button>
 				</div>
 			</div>
@@ -115,7 +115,7 @@
 						<span class="pageCategory">Date:</span> <span class="pageData" aria-describedby="mDate">{{ message.date }}</span>
 					</div>
 					<div class="threadBtns">
-						<a [routerLink]="['/new', 'Message']" [queryParams]="{user: message.from, userID: message.fromId}" class="appButton messageButton" [attr.aria-describedby]="'mReply ' + 'mText' + message.id">Reply</a>
+						<a [routerLink]="['/new', 'Message']" [queryParams]="{user: message.from.displayName, userID: message.fromId}" class="appButton messageButton" [attr.aria-describedby]="'mReply ' + 'mText' + message.id">Reply</a>
 						<button class="appButton deleteButton" (click)="deleteMessage(message.id)" [attr.aria-describedby]="'mDelete ' + 'mText' + message.id">Delete Message</button>
 					</div>
 				</div>


### PR DESCRIPTION
**Description**

When clicking "reply" in the messages' view, the users are sent to the "new message" view, where they can write a new message. The page contains a "for" field which should show the name of the user to send a message to; however, it showed `[object object]`.

This was an elusive one as that issue only happens when trying to reply from the messages' views; in the rest of the time it worked perfectly fine.

**Issue link**

--

**Expected behavior**

The field should show the same thing as it does when sending a message in response to a post - the name of the user.

**Your solution**

Changed the parameter we pass in as `user` to be the display name of the user, instead of the whole object (which contains the details of their user pictures as well).

**Additional information**

--