### PR TITLE
change: Rebuilt the Settings Update form in a more intuitive way.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+#### Changes
+
+- Replaced the "enable/disable push notifications" and the "enable/disable auto-refresh" buttons in the Settings view with checkboxes. The new checkboxes are now part of the form in the view (instead of the "save" button only impacting the "refresh rate" field). This makes the "update settings" section (and the form within it) considerably more intuitive to use ([#1571](https://github.com/sendahug/send-hug-frontend/pull/1571)).
+- Replaced the old "settings update" form with an Angular reactive form, which simplifies form validation ([#1571](https://github.com/sendahug/send-hug-frontend/pull/1571)).
+
+### 2024-04-01
+
 #### Fixes
 
 - Fixed a bug where the "new messages" screen accidentally showed `[object object]` instead of the name of the user to send a message to in the "for" field when users tried to send a new message from the messages' views ([#1569](https://github.com/sendahug/send-hug-frontend/pull/1569)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 #### Changes
 
-- Replaced the "enable/disable push notifications" and the "enable/disable auto-refresh" buttons in the Settings view with checkboxes. The new checkboxes are now part of the form in the view (instead of the "save" button only impacting the "refresh rate" field). This makes the "update settings" section (and the form within it) considerably more intuitive to use ([#1571](https://github.com/sendahug/send-hug-frontend/pull/1571)).
-- Replaced the old "settings update" form with an Angular reactive form, which simplifies form validation ([#1571](https://github.com/sendahug/send-hug-frontend/pull/1571)).
+- Replaced the "enable/disable push notifications" and the "enable/disable auto-refresh" buttons in the Settings view with checkboxes. The new checkboxes are now part of the form in the view (instead of the "save" button only impacting the "refresh rate" field). This makes the "update settings" section (and the form within it) considerably more intuitive to use ([#1572](https://github.com/sendahug/send-hug-frontend/pull/1572)).
+- Replaced the old "settings update" form with an Angular reactive form, which simplifies form validation ([#1572](https://github.com/sendahug/send-hug-frontend/pull/1572)).
 
 ### 2024-04-01
 

--- a/src/app/components/settings/settings.component.html
+++ b/src/app/components/settings/settings.component.html
@@ -22,14 +22,36 @@
 	
 	<div id="notificationSettings">
 		<h4>Notifications</h4>
-		<button class="appButton NotificationButton" (click)="togglePushNotifications()">{{ notificationService.toggleBtn }} Push Notifications</button>
-		<button class="appButton NotificationButton" (click)="toggleAutoRefresh()">{{ notificationService.refreshBtn }} Auto-Refresh</button>
-		<form id="refreshRateForm">
+		<form [formGroup]="editSettingsForm" id="refreshRateForm">
+			<div class="formElement">
+				<label for="enableNotifications" class="required">Push Notifications Enabled?:</label>
+				<input
+					formControlName="enableNotifications"
+					type="checkbox"
+					id="enableNotifications"
+				>
+			</div>
+			<div class="formElement">
+				<label for="enableAutoRefresh" class="required">Auto-Refresh Enabled?:</label>
+				<input
+					formControlName="enableAutoRefresh"
+					type="checkbox"
+					id="enableAutoRefresh"
+				>
+			</div>
 			<div class="formElement">
 				<label for="notificationRate" class="required">Notifications auto-refresh rate:</label>
-				<input type="number" min="20" max="3600" id="notificationRate" value="(notificationService.refreshRateSecs)" #notificationRate aria-invalid="false" required aria-required="true">
+				<input
+					formControlName="notificationRate"
+					type="number"
+					min="20"
+					max="3600"
+					id="notificationRate"
+					[required]="this.editSettingsForm.get('enableAutoRefresh')?.value == true"
+					[attr.aria-required]="this.editSettingsForm.get('enableAutoRefresh')?.value == true"
+				>
 			</div>
-			<button type="submit" (click)="updateRefreshRate($event, notificationRate.value)" class="appButton sendData" aria-label="save auto-refresh settings">Save</button>
+			<button type="submit" (click)="updateSettings()" class="appButton sendData" aria-label="save auto-refresh settings">Save</button>
 		</form>
 		
 	</div>

--- a/src/app/components/settings/settings.component.spec.ts
+++ b/src/app/components/settings/settings.component.spec.ts
@@ -41,16 +41,14 @@ import {
 import { HttpClientModule } from "@angular/common/http";
 import { ServiceWorkerModule } from "@angular/service-worker";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
+import { ReactiveFormsModule } from "@angular/forms";
 
-import { AppComponent } from "../../app.component";
 import { SettingsPage } from "./settings.component";
-import { IconEditor } from "../iconEditor/iconEditor.component";
-import { NotificationService } from "../../services/notifications.service";
-import { AuthService } from "../../services/auth.service";
-import { NotificationsTab } from "../notifications/notifications.component";
-import { AlertsService } from "../../services/alerts.service";
+import { IconEditor } from "@app/components/iconEditor/iconEditor.component";
+import { NotificationService } from "@app/services/notifications.service";
+import { AuthService } from "@app/services/auth.service";
+import { AlertsService } from "@app/services/alerts.service";
 import { mockAuthedUser } from "@tests/mockData";
-import { AppAlert } from "../appAlert/appAlert.component";
 
 describe("SettingsPage", () => {
   // Before each test, configure testing environment
@@ -64,8 +62,9 @@ describe("SettingsPage", () => {
         HttpClientModule,
         ServiceWorkerModule.register("sw.js", { enabled: false }),
         FontAwesomeModule,
+        ReactiveFormsModule,
       ],
-      declarations: [AppComponent, SettingsPage, NotificationsTab, IconEditor, AppAlert],
+      declarations: [SettingsPage, IconEditor],
       providers: [{ provide: APP_BASE_HREF, useValue: "/" }],
     }).compileComponents();
 
@@ -80,17 +79,13 @@ describe("SettingsPage", () => {
 
   // Check that the app is created
   it("should create the app", () => {
-    const acFixture = TestBed.createComponent(AppComponent);
-    const appComponent = acFixture.componentInstance;
     const fixture = TestBed.createComponent(SettingsPage);
     const settingsPage = fixture.componentInstance;
-    expect(appComponent).toBeTruthy();
     expect(settingsPage).toBeTruthy();
   });
 
   // Check that the user has to be logged in to interact with the component
   it("displays an error when not authenticated", (done: DoneFn) => {
-    TestBed.createComponent(AppComponent);
     const fixture = TestBed.createComponent(SettingsPage);
     const settingsPage = fixture.componentInstance;
     const settingsDOM = fixture.nativeElement;
@@ -110,7 +105,6 @@ describe("SettingsPage", () => {
   });
 
   it("should show the icon editor", (done: DoneFn) => {
-    TestBed.createComponent(AppComponent);
     const fixture = TestBed.createComponent(SettingsPage);
     const settingsPage = fixture.componentInstance;
     settingsPage.authService.authenticated = false;
@@ -124,7 +118,6 @@ describe("SettingsPage", () => {
   });
 
   it("should hide the icon editor", (done: DoneFn) => {
-    TestBed.createComponent(AppComponent);
     const fixture = TestBed.createComponent(SettingsPage);
     const settingsPage = fixture.componentInstance;
     settingsPage.authService.authenticated = false;
@@ -138,50 +131,50 @@ describe("SettingsPage", () => {
   });
 
   // Check that the button toggles push notifications
-  it("has a button that toggles push notifications", (done: DoneFn) => {
-    // set up the component and its spies
-    TestBed.createComponent(AppComponent);
-    const fixture = TestBed.createComponent(SettingsPage);
-    const settingsPage = fixture.componentInstance;
-    const settingsDOM = fixture.nativeElement;
-    const toggleSpy = spyOn(settingsPage, "togglePushNotifications").and.callThrough();
-    const notificationsService = settingsPage.notificationService;
-    const settingsSpy = spyOn(notificationsService, "updateUserSettings").and.callThrough();
-    const subscribeSpy = spyOn(notificationsService, "subscribeToStream").and.callThrough();
-    const unsubscribeSpy = spyOn(notificationsService, "unsubscribeFromStream").and.callThrough();
+  // it("has a button that toggles push notifications", (done: DoneFn) => {
+  //   // set up the component and its spies
+  //   TestBed.createComponent(AppComponent);
+  //   const fixture = TestBed.createComponent(SettingsPage);
+  //   const settingsPage = fixture.componentInstance;
+  //   const settingsDOM = fixture.nativeElement;
+  //   const toggleSpy = spyOn(settingsPage, "togglePushNotifications").and.callThrough();
+  //   const notificationsService = settingsPage.notificationService;
+  //   const settingsSpy = spyOn(notificationsService, "updateUserSettings").and.callThrough();
+  //   const subscribeSpy = spyOn(notificationsService, "subscribeToStream").and.callThrough();
+  //   const unsubscribeSpy = spyOn(notificationsService, "unsubscribeFromStream").and.callThrough();
 
-    fixture.detectChanges();
+  //   fixture.detectChanges();
 
-    // before the click
-    expect(settingsPage.notificationService.pushStatus).toBeFalse();
+  //   // before the click
+  //   expect(settingsPage.notificationService.pushStatus).toBeFalse();
 
-    // simulate click
-    settingsDOM.querySelectorAll(".NotificationButton")[0].click();
-    fixture.detectChanges();
+  //   // simulate click
+  //   settingsDOM.querySelectorAll(".NotificationButton")[0].click();
+  //   fixture.detectChanges();
 
-    // after the first click, check 'subscribe' was called
-    expect(toggleSpy).toHaveBeenCalled();
-    expect(settingsPage.notificationService.pushStatus).toBeTrue();
-    expect(settingsSpy).toHaveBeenCalled();
-    expect(subscribeSpy).toHaveBeenCalled();
-    expect(unsubscribeSpy).not.toHaveBeenCalled();
+  //   // after the first click, check 'subscribe' was called
+  //   expect(toggleSpy).toHaveBeenCalled();
+  //   expect(settingsPage.notificationService.pushStatus).toBeTrue();
+  //   expect(settingsSpy).toHaveBeenCalled();
+  //   expect(subscribeSpy).toHaveBeenCalled();
+  //   expect(unsubscribeSpy).not.toHaveBeenCalled();
 
-    // simulate another click
-    settingsDOM.querySelectorAll(".NotificationButton")[0].click();
-    fixture.detectChanges();
+  //   // simulate another click
+  //   settingsDOM.querySelectorAll(".NotificationButton")[0].click();
+  //   fixture.detectChanges();
 
-    // after the second click, chcek 'unsubscribe' was called
-    expect(toggleSpy.calls.count()).toBe(2);
-    expect(settingsPage.notificationService.pushStatus).toBeFalse();
-    expect(settingsSpy.calls.count()).toBe(2);
-    expect(subscribeSpy.calls.count()).toBe(1);
-    expect(unsubscribeSpy).toHaveBeenCalled();
-    expect(unsubscribeSpy.calls.count()).toBe(1);
-    done();
-  });
+  //   // after the second click, chcek 'unsubscribe' was called
+  //   expect(toggleSpy.calls.count()).toBe(2);
+  //   expect(settingsPage.notificationService.pushStatus).toBeFalse();
+  //   expect(settingsSpy.calls.count()).toBe(2);
+  //   expect(subscribeSpy.calls.count()).toBe(1);
+  //   expect(unsubscribeSpy).toHaveBeenCalled();
+  //   expect(unsubscribeSpy.calls.count()).toBe(1);
+  //   done();
+  // });
 
   // Check that the button toggles auto refresh
-  it("has a button that toggles auto-refresh", (done: DoneFn) => {
+  it("has a checkbox that toggles auto-refresh", (done: DoneFn) => {
     // set up spies
     const notificationsService = TestBed.inject(NotificationService);
     const settingsSpy = spyOn(notificationsService, "updateUserSettings");
@@ -189,36 +182,41 @@ describe("SettingsPage", () => {
     const stopRefreshSpy = spyOn(notificationsService, "stopAutoRefresh");
 
     // set up the component
-    TestBed.createComponent(AppComponent);
     const fixture = TestBed.createComponent(SettingsPage);
     const settingsPage = fixture.componentInstance;
     const settingsDOM = fixture.nativeElement;
-    const toggleSpy = spyOn(settingsPage, "toggleAutoRefresh").and.callThrough();
+    const toggleSpy = spyOn(settingsPage, "updateSettings").and.callThrough();
     fixture.detectChanges();
 
     // before the click
     expect(settingsPage.notificationService.refreshStatus).toBeFalse();
 
     // simulate click
-    settingsDOM.querySelectorAll(".NotificationButton")[1].click();
+    settingsDOM.querySelector("#enableAutoRefresh").click();
+    settingsDOM.querySelector("#enableAutoRefresh").dispatchEvent(new Event("input"));
+    settingsDOM.querySelector("#notificationRate").value = 30;
+    settingsDOM.querySelector("#notificationRate").dispatchEvent(new Event("input"));
+    settingsDOM.querySelectorAll(".sendData")[0].click();
     fixture.detectChanges();
 
     // after the first click, check 'subscribe' was called
     expect(toggleSpy).toHaveBeenCalled();
     expect(settingsPage.notificationService.refreshStatus).toBeTrue();
-    expect(settingsPage.notificationService.refreshRateSecs).toBe(20);
+    expect(settingsPage.notificationService.refreshRateSecs).toBe(30);
     expect(settingsSpy).toHaveBeenCalled();
     expect(startRefreshSpy).toHaveBeenCalled();
     expect(stopRefreshSpy).not.toHaveBeenCalled();
 
     // simulate another click
-    settingsDOM.querySelectorAll(".NotificationButton")[1].click();
+    settingsDOM.querySelector("#enableAutoRefresh").click();
+    settingsDOM.querySelector("#enableAutoRefresh").dispatchEvent(new Event("input"));
+    settingsDOM.querySelectorAll(".sendData")[0].click();
     fixture.detectChanges();
 
     // after the second click, chcek 'unsubscribe' was called
     expect(toggleSpy.calls.count()).toBe(2);
     expect(settingsPage.notificationService.refreshStatus).toBeFalse();
-    expect(settingsPage.notificationService.refreshRateSecs).toBe(0);
+    expect(settingsPage.notificationService.refreshRateSecs).toBe(30);
     expect(settingsSpy.calls.count()).toBe(2);
     expect(startRefreshSpy.calls.count()).toBe(1);
     expect(stopRefreshSpy).toHaveBeenCalled();
@@ -236,7 +234,7 @@ describe("SettingsPage", () => {
     const fixture = TestBed.createComponent(SettingsPage);
     const settingsPage = fixture.componentInstance;
     const settingsDOM = fixture.nativeElement;
-    const updateSpy = spyOn(settingsPage, "updateRefreshRate").and.callThrough();
+    const updateSpy = spyOn(settingsPage, "updateSettings").and.callThrough();
     settingsPage.authService.authenticated = true;
 
     fixture.detectChanges();
@@ -247,7 +245,10 @@ describe("SettingsPage", () => {
       expect(updateSpy).not.toHaveBeenCalled();
 
       // change the rate
-      settingsDOM.querySelectorAll("input")[0].value = 30;
+      settingsDOM.querySelector("#enableAutoRefresh").click();
+      settingsDOM.querySelector("#enableAutoRefresh").dispatchEvent(new Event("input"));
+      settingsDOM.querySelector("#notificationRate").value = 30;
+      settingsDOM.querySelector("#notificationRate").dispatchEvent(new Event("input"));
       settingsDOM.querySelectorAll(".sendData")[0].click();
       fixture.detectChanges();
 
@@ -278,7 +279,10 @@ describe("SettingsPage", () => {
       expect(settingsPage.notificationService.refreshRateSecs).toBe(20);
 
       // change the rate
-      settingsDOM.querySelectorAll("input")[0].value = "";
+      settingsDOM.querySelector("#enableAutoRefresh").click();
+      settingsDOM.querySelector("#enableAutoRefresh").dispatchEvent(new Event("input"));
+      settingsDOM.querySelector("#notificationRate").value = 0;
+      settingsDOM.querySelector("#notificationRate").dispatchEvent(new Event("input"));
       settingsDOM.querySelectorAll(".sendData")[0].click();
       fixture.detectChanges();
 
@@ -289,7 +293,7 @@ describe("SettingsPage", () => {
         type: "Error",
         message: "Refresh rate cannot be empty or zero. Please fill the field and try again.",
       });
-      expect(document.getElementById("notificationRate")!.className).toBe("missing");
+      expect(document.getElementById("notificationRate")!.className).toContain("ng-invalid");
       expect(document.getElementById("notificationRate")!.getAttribute("aria-invalid")).toEqual(
         "true",
       );

--- a/src/app/components/settings/settings.component.spec.ts
+++ b/src/app/components/settings/settings.component.spec.ts
@@ -130,50 +130,55 @@ describe("SettingsPage", () => {
     done();
   });
 
-  // Check that the button toggles push notifications
-  // it("has a button that toggles push notifications", (done: DoneFn) => {
-  //   // set up the component and its spies
-  //   TestBed.createComponent(AppComponent);
-  //   const fixture = TestBed.createComponent(SettingsPage);
-  //   const settingsPage = fixture.componentInstance;
-  //   const settingsDOM = fixture.nativeElement;
-  //   const toggleSpy = spyOn(settingsPage, "togglePushNotifications").and.callThrough();
-  //   const notificationsService = settingsPage.notificationService;
-  //   const settingsSpy = spyOn(notificationsService, "updateUserSettings").and.callThrough();
-  //   const subscribeSpy = spyOn(notificationsService, "subscribeToStream").and.callThrough();
-  //   const unsubscribeSpy = spyOn(notificationsService, "unsubscribeFromStream").and.callThrough();
+  // Check that the checkbox toggles push notifications
+  it("has a checkbox that toggles push notifications", (done: DoneFn) => {
+    const notificationsService = TestBed.inject(NotificationService);
+    notificationsService.refreshStatus = false;
 
-  //   fixture.detectChanges();
+    // set up the component and its spies
+    const fixture = TestBed.createComponent(SettingsPage);
+    const settingsPage = fixture.componentInstance;
+    const settingsDOM = fixture.nativeElement;
+    const toggleSpy = spyOn(settingsPage, "updateSettings").and.callThrough();
+    const settingsSpy = spyOn(notificationsService, "updateUserSettings");
+    const subscribeSpy = spyOn(notificationsService, "subscribeToStream");
+    const unsubscribeSpy = spyOn(notificationsService, "unsubscribeFromStream");
 
-  //   // before the click
-  //   expect(settingsPage.notificationService.pushStatus).toBeFalse();
+    fixture.detectChanges();
 
-  //   // simulate click
-  //   settingsDOM.querySelectorAll(".NotificationButton")[0].click();
-  //   fixture.detectChanges();
+    // before the click
+    expect(settingsPage.notificationService.pushStatus).toBeFalse();
 
-  //   // after the first click, check 'subscribe' was called
-  //   expect(toggleSpy).toHaveBeenCalled();
-  //   expect(settingsPage.notificationService.pushStatus).toBeTrue();
-  //   expect(settingsSpy).toHaveBeenCalled();
-  //   expect(subscribeSpy).toHaveBeenCalled();
-  //   expect(unsubscribeSpy).not.toHaveBeenCalled();
+    // simulate click
+    settingsDOM.querySelector("#enableNotifications").click();
+    settingsDOM.querySelector("#enableNotifications").dispatchEvent(new Event("input"));
+    settingsDOM.querySelectorAll(".sendData")[0].click();
+    fixture.detectChanges();
 
-  //   // simulate another click
-  //   settingsDOM.querySelectorAll(".NotificationButton")[0].click();
-  //   fixture.detectChanges();
+    // after the first click, check 'subscribe' was called
+    expect(toggleSpy).toHaveBeenCalled();
+    expect(settingsPage.notificationService.pushStatus).toBeTrue();
+    expect(settingsSpy).toHaveBeenCalled();
+    expect(subscribeSpy).toHaveBeenCalled();
+    expect(unsubscribeSpy).not.toHaveBeenCalled();
 
-  //   // after the second click, chcek 'unsubscribe' was called
-  //   expect(toggleSpy.calls.count()).toBe(2);
-  //   expect(settingsPage.notificationService.pushStatus).toBeFalse();
-  //   expect(settingsSpy.calls.count()).toBe(2);
-  //   expect(subscribeSpy.calls.count()).toBe(1);
-  //   expect(unsubscribeSpy).toHaveBeenCalled();
-  //   expect(unsubscribeSpy.calls.count()).toBe(1);
-  //   done();
-  // });
+    // simulate another click
+    settingsDOM.querySelector("#enableNotifications").click();
+    settingsDOM.querySelector("#enableNotifications").dispatchEvent(new Event("input"));
+    settingsDOM.querySelectorAll(".sendData")[0].click();
+    fixture.detectChanges();
 
-  // Check that the button toggles auto refresh
+    // after the second click, chcek 'unsubscribe' was called
+    expect(toggleSpy.calls.count()).toBe(2);
+    expect(settingsPage.notificationService.pushStatus).toBeFalse();
+    expect(settingsSpy.calls.count()).toBe(2);
+    expect(subscribeSpy.calls.count()).toBe(1);
+    expect(unsubscribeSpy).toHaveBeenCalled();
+    expect(unsubscribeSpy.calls.count()).toBe(1);
+    done();
+  });
+
+  // Check that the checkbox toggles auto refresh
   it("has a checkbox that toggles auto-refresh", (done: DoneFn) => {
     // set up spies
     const notificationsService = TestBed.inject(NotificationService);

--- a/src/app/components/settings/settings.component.spec.ts
+++ b/src/app/components/settings/settings.component.spec.ts
@@ -130,6 +130,28 @@ describe("SettingsPage", () => {
     done();
   });
 
+  it("pre-fills the form based on the user's settings", (done: DoneFn) => {
+    const authService = TestBed.inject(AuthService);
+    authService.isUserDataResolved.next(false);
+
+    // set up the component and its spies
+    const fixture = TestBed.createComponent(SettingsPage);
+    const settingsPage = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(settingsPage.editSettingsForm.get("enableAutoRefresh")?.value).toBeFalse();
+    expect(settingsPage.editSettingsForm.get("notificationRate")?.value).toBe(20);
+
+    authService.userData.autoRefresh = true;
+    authService.userData.refreshRate = 60;
+    authService.isUserDataResolved.next(true);
+    fixture.detectChanges();
+
+    expect(settingsPage.editSettingsForm.get("enableAutoRefresh")?.value).toBeTrue();
+    expect(settingsPage.editSettingsForm.get("notificationRate")?.value).toBe(60);
+    done();
+  });
+
   // Check that the checkbox toggles push notifications
   it("has a checkbox that toggles push notifications", (done: DoneFn) => {
     const notificationsService = TestBed.inject(NotificationService);

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -70,11 +70,11 @@ export class SettingsPage implements AfterViewChecked {
       }
     });
 
-    this.editSettingsForm.get("enableAutoRefresh")?.valueChanges.subscribe(() => {
+    this.editSettingsForm.controls.enableAutoRefresh.valueChanges.subscribe(() => {
       this.updateNotificationRateValidators();
     });
 
-    this.editSettingsForm.get("notificationRate")?.valueChanges.subscribe(() => {
+    this.editSettingsForm.controls.notificationRate.valueChanges.subscribe(() => {
       this.setRateInvalidStatus();
     });
   }
@@ -158,9 +158,10 @@ export class SettingsPage implements AfterViewChecked {
    */
   updateNotificationRateValidators() {
     if (this.editSettingsForm.get("enableAutoRefresh")?.value) {
-      this.editSettingsForm
-        .get("notificationRate")
-        ?.setValidators([Validators.required, Validators.min(20)]);
+      this.editSettingsForm.controls.notificationRate.setValidators([
+        Validators.required,
+        Validators.min(20),
+      ]);
     } else {
       this.editSettingsForm.get("notificationRate")?.clearValidators();
     }

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -137,9 +137,9 @@ export class SettingsPage implements AfterViewChecked {
     }
 
     if (this.editSettingsForm.valid) {
-      this.notificationService.pushStatus = refreshStatus;
-      this.notificationService.refreshStatus =
-        this.editSettingsForm.get("enableAutoRefresh")?.value || false;
+      this.notificationService.pushStatus =
+        this.editSettingsForm.get("enableNotifications")?.value || false;
+      this.notificationService.refreshStatus = refreshStatus;
       this.notificationService.refreshRateSecs = Number(newRate);
       this.notificationService.updateUserSettings();
 

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -32,6 +32,7 @@
 
 // Angular imports
 import { Component, AfterViewChecked } from "@angular/core";
+import { FormBuilder, Validators } from "@angular/forms";
 
 // App-related imports
 import { NotificationService } from "@app/services/notifications.service";
@@ -45,13 +46,38 @@ import { iconElements } from "@app/interfaces/types";
 })
 export class SettingsPage implements AfterViewChecked {
   editIcon = false;
+  editSettingsForm = this.fb.group({
+    enableNotifications: [false],
+    enableAutoRefresh: [false],
+    notificationRate: [20],
+  });
 
   // CTOR
   constructor(
     public notificationService: NotificationService,
     public authService: AuthService,
     private alertsService: AlertsService,
-  ) {}
+    private fb: FormBuilder,
+  ) {
+    // TODO: There's got to be a better way to do this for refreshes...
+    this.authService.isUserDataResolved.subscribe((value) => {
+      if (value) {
+        this.editSettingsForm.setValue({
+          enableNotifications: this.notificationService.pushStatus || false,
+          enableAutoRefresh: this.notificationService.refreshStatus || false,
+          notificationRate: this.notificationService.refreshRateSecs,
+        });
+      }
+    });
+
+    this.editSettingsForm.get("enableAutoRefresh")?.valueChanges.subscribe(() => {
+      this.updateNotificationRateValidators();
+    });
+
+    this.editSettingsForm.get("notificationRate")?.valueChanges.subscribe(() => {
+      this.setRateInvalidStatus();
+    });
+  }
 
   /*
   Function Name: ngAfterViewChecked()
@@ -95,77 +121,70 @@ export class SettingsPage implements AfterViewChecked {
     }
   }
 
-  /*
-  Function Name: togglePushNotifications()
-  Function Description: Enables and disables push notifications.
-  Parameters: None.
-  ----------------
-  Programmer: Shir Bar Lev.
-  */
-  togglePushNotifications() {
-    // if notifications are enabled, disable them
-    if (this.notificationService.pushStatus) {
-      this.notificationService.pushStatus = false;
-      this.notificationService.updateUserSettings();
-      this.notificationService.unsubscribeFromStream();
-    }
-    // otherwise enable them
-    else {
-      this.notificationService.pushStatus = true;
-      this.notificationService.updateUserSettings();
-      this.notificationService.subscribeToStream();
-    }
-  }
+  /**
+   * Updates the user's settings based on the form values.
+   */
+  updateSettings() {
+    const newRate = this.editSettingsForm.get("notificationRate")?.value;
+    const refreshStatus = this.editSettingsForm.get("enableAutoRefresh")?.value || false;
 
-  /*
-  Function Name: togglePushNotifications()
-  Function Description: Enables and disables automatically refreshing the user's
-                        notifications in the background.
-  Parameters: None.
-  ----------------
-  Programmer: Shir Bar Lev.
-  */
-  toggleAutoRefresh() {
-    // if auto-refresh is enabled, disable it
-    if (this.notificationService.refreshStatus) {
-      this.notificationService.refreshStatus = false;
-      this.notificationService.refreshRateSecs = 0;
-      this.notificationService.updateUserSettings();
-      this.notificationService.stopAutoRefresh();
-    }
-    // otherwise enable it
-    else {
-      this.notificationService.refreshStatus = true;
-      this.notificationService.refreshRateSecs = 20;
-      this.notificationService.updateUserSettings();
-      this.notificationService.startAutoRefresh();
-    }
-  }
-
-  /*
-  Function Name: updateRefreshRate()
-  Function Description: Updates the user's auto-refersh rate.
-  Parameters: e (event) - the button click that triggers the method.
-              newRate (number) - the new refresh rate in seconds.
-  ----------------
-  Programmer: Shir Bar Lev.
-  */
-  updateRefreshRate(e: Event, newRate: number) {
-    e.preventDefault();
-
-    // if there's a new rate, update user settings
-    if (newRate && newRate > 0) {
-      this.notificationService.refreshRateSecs = Number(newRate);
-      this.notificationService.updateUserSettings();
-    }
     // if there's no rate or it's zero, alert the user it can't be
-    else {
+    if ((!newRate || newRate <= 0) && refreshStatus) {
       this.alertsService.createAlert({
         type: "Error",
         message: "Refresh rate cannot be empty or zero. Please fill the field and try again.",
       });
-      document.getElementById("notificationRate")!.classList.add("missing");
-      document.getElementById("notificationRate")!.setAttribute("aria-invalid", "true");
+    }
+
+    if (this.editSettingsForm.valid) {
+      this.notificationService.pushStatus = refreshStatus;
+      this.notificationService.refreshStatus =
+        this.editSettingsForm.get("enableAutoRefresh")?.value || false;
+      this.notificationService.refreshRateSecs = Number(newRate);
+      this.notificationService.updateUserSettings();
+
+      if (this.notificationService.refreshStatus) this.notificationService.startAutoRefresh();
+      else this.notificationService.stopAutoRefresh();
+
+      if (this.notificationService.pushStatus) this.notificationService.subscribeToStream();
+      else this.notificationService.unsubscribeFromStream();
+    }
+  }
+
+  /**
+   * Changes the validators of the rate field based on the auto-refresh status.
+   * If auto-refresh is enabled, the rate field is required and must be higher than
+   * 20 (seconds); otherwise it's not.
+   */
+  updateNotificationRateValidators() {
+    if (this.editSettingsForm.get("enableAutoRefresh")?.value) {
+      this.editSettingsForm
+        .get("notificationRate")
+        ?.setValidators([Validators.required, Validators.min(20)]);
+    } else {
+      this.editSettingsForm.get("notificationRate")?.clearValidators();
+    }
+
+    this.setRateInvalidStatus();
+  }
+
+  /**
+   * Sets the aria-invalid attribute of the rate field based on its validity.
+   * TODO: We shouldn't have to do this manually, but it seems that process
+   * of changing it is running too slowly, which causes an
+   * ExpressionChangedAfterItHasBeenCheckedError error.
+   */
+  setRateInvalidStatus() {
+    const currentRate = this.editSettingsForm.get("notificationRate");
+
+    if (this.editSettingsForm.get("enableAutoRefresh")?.value === true) {
+      if (currentRate && (!currentRate.value || (currentRate.value && currentRate.value < 20))) {
+        document.querySelector("#notificationRate")?.setAttribute("aria-invalid", "true");
+      } else {
+        document.querySelector("#notificationRate")?.setAttribute("aria-invalid", "false");
+      }
+    } else {
+      document.querySelector("#notificationRate")?.setAttribute("aria-invalid", "false");
     }
   }
 }

--- a/src/app/services/notifications.service.ts
+++ b/src/app/services/notifications.service.ts
@@ -59,12 +59,12 @@ export class NotificationService {
   notificationsSub: PushSubscription | undefined;
   subId = 0;
   newNotifications = 0;
-  pushStatus!: Boolean;
+  pushStatus: boolean = false;
   resubscribeCalls = 0;
   pushDate = 0;
   // notifications refresh variables
   refreshBtn!: "Enable" | "Disable";
-  refreshStatus!: Boolean;
+  refreshStatus: boolean = false;
   refreshRateSecs = 20;
   refreshCounter: Observable<number> | undefined;
   refreshSub: Subscription | undefined;
@@ -83,9 +83,6 @@ export class NotificationService {
         this.pushStatus = this.authService.userData.pushEnabled;
         this.refreshStatus = this.authService.userData.autoRefresh;
         this.refreshRateSecs = this.authService.userData.refreshRate;
-      } else {
-        this.pushStatus = false;
-        this.refreshStatus = false;
       }
 
       this.toggleBtn = this.pushStatus ? "Disable" : "Enable";


### PR DESCRIPTION
**Description**

The settings update form consists of one field (the refresh rate), despite being in the same graphic area as the "auto refresh" and "notifications" buttons. This is unintuitive and confusing. Also, we handle all data and validation (as well as setting the class of the input field) manually instead of using a reactive form.

**Issue link**

--

**Expected behavior**

The whole settings update section should be handled by the form, as the graphic presentation indicates to users that it is.

**Your solution**

Combined the two sections into a single form by replacing the buttons with checkboxes, which are now handled by the form.

Also updated the form to use a reactive form.

**Additional information**

--.