### PR TITLE
chore: Fixed CI's setup for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,10 +76,11 @@ jobs:
       - run:
           name: Restore database
           command: |
+            cd ..
             ls
-            cd ../send-hug-backend
-            mv ../send-hug-frontend/e2e/setup.py .
-            python3 -m setup.py
+            mv ./send-hug-frontend/e2e/setup.py ./send-hug-backend
+            cd send-hug-backend
+            python3 setup.py
       - run:
           name: Start backend
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
       - run:
           name: Restore database
           command: |
+            ls
             cd ../send-hug-backend
             mv ../send-hug-frontend/e2e/setup.py .
             python3 -m setup.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,10 +76,9 @@ jobs:
       - run:
           name: Restore database
           command: |
-            cd ..
             ls
-            mv ./send-hug-frontend/e2e/setup.py ./send-hug-backend
-            cd send-hug-backend
+            mv ./send-hug-frontend/e2e/setup.py ../send-hug-backend
+            cd ../send-hug-backend
             python3 setup.py
       - run:
           name: Start backend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - run:
           name: Restore database
           command: |
-            mv /e2e/setup.py ../send-hug-backend
+            mv e2e/setup.py ../send-hug-backend
             cd ../send-hug-backend
             python3 setup.py
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,9 @@ jobs:
       - run:
           name: Restore database
           command: |
-            cd ..
-            psql -h localhost -p 5432 -U postgres test_sah < send-hug-backend/tests/capstone_db.sql
+            cd ../send-hug-backend
+            mv ../send-hug-frontend/e2e/setup.py .
+            python3 -m setup.py
       - run:
           name: Start backend
           command: |
@@ -147,8 +148,9 @@ jobs:
       - run:
           name: Restore database
           command: |
-            cd ..
-            psql -h localhost -p 5432 -U postgres test_sah < send-hug-backend/tests/capstone_db.sql
+            cd ../send-hug-backend
+            mv ../send-hug-frontend/e2e/setup.py .
+            python3 -m setup.py
       - run:
           name: Start backend
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,7 @@ jobs:
       - run:
           name: Restore database
           command: |
-            ls
-            mv ./send-hug-frontend/e2e/setup.py ../send-hug-backend
+            mv /e2e/setup.py ../send-hug-backend
             cd ../send-hug-backend
             python3 setup.py
       - run:
@@ -149,9 +148,9 @@ jobs:
       - run:
           name: Restore database
           command: |
+            mv e2e/setup.py ../send-hug-backend
             cd ../send-hug-backend
-            mv ../send-hug-frontend/e2e/setup.py .
-            python3 -m setup.py
+            python3 setup.py
       - run:
           name: Start backend
           command: |

--- a/changelog/pr1588.json
+++ b/changelog/pr1588.json
@@ -1,0 +1,9 @@
+{
+  "pr_number": 1588,
+  "changes": [
+    {
+      "change": "Chores",
+      "description": "Updated the process in which we populate the test database in CI to match the updated structure of the test data in the back-end (see [sendahug/send-hug#601](https://github.com/sendahug/send-hug-backend/pull/601))."
+    }
+  ]
+}

--- a/changelog/pr1588.json
+++ b/changelog/pr1588.json
@@ -3,7 +3,7 @@
   "changes": [
     {
       "change": "Chores",
-      "description": "Updated the process in which we populate the test database in CI to match the updated structure of the test data in the back-end (see [sendahug/send-hug#601](https://github.com/sendahug/send-hug-backend/pull/601))."
+      "description": "Updated the process of populating the test database in CI to match the updated structure of the test data in the back-end (see [sendahug/send-hug#601](https://github.com/sendahug/send-hug-backend/pull/601))."
     }
   ]
 }

--- a/e2e/setup.py
+++ b/e2e/setup.py
@@ -1,0 +1,13 @@
+from create_app import create_app
+from models.models import db
+from tests.data_models import create_data
+
+
+def setup_e2e():
+    """Sets up the database ahead of e2e tests"""
+    test_db_path = "postgresql://postgres:password@localhost:5432/test_sah"
+    app = create_app(test_db_path)
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        create_data(db)

--- a/e2e/setup.py
+++ b/e2e/setup.py
@@ -11,3 +11,6 @@ def setup_e2e():
         db.drop_all()
         db.create_all()
         create_data(db)
+
+if __name__ == "__main__":
+    setup_e2e()


### PR DESCRIPTION
**Description**

In sendahug/send-hug-backend#601 we updated the way the tests' database is populated, which broke e2e tests as e2e tests expected a SQL file to populate the database from.

**Issue link**

--

**Expected behavior**

e2e and accessibility tests should run and populate the database correctly.

**Your solution**

Added a script to populate the database using the SQLAlchemy script.

**Additional information**

--
