### PR TITLE
change: Simplified the Display Name Edit Form's inputs.

### DIFF
--- a/changelog/pr1602.json
+++ b/changelog/pr1602.json
@@ -1,0 +1,21 @@
+{
+  "pr_number": 1602,
+  "changes": [
+    {
+      "change": "Fixes",
+      "description": "Fixed a bug where the Admin Reports' report list accidentally showed `singal` instead of the current page and total page values."
+    },
+    {
+      "change": "Fixes",
+      "description": "Added the missing reportData input to all forms in the Admin Reports component. This fixes an error that caused the forms to ignore attempts to close reports when editing posts and users and when deleting posts."
+    },
+    {
+      "change": "Changes",
+      "description": "Simplified the inputs to the Display Name Edit Form. Previously, the form relied on a separate input to indicate whether it should fetch the name to edit from the Auth Service or from the form input (which was a string). This was unnecessarily complicated. Now, both the Admin Reports screen and the User page screen pass in an object that contains the ID and name of the user to edit. When the form is submitted, the ID of the user is compared to the ID of the currently logged in user (in the Auth Service). If it's the same, the request is made via the auth service; otherwise, it's made via the Admin Service."
+    },
+    {
+      "change": "Fixes",
+      "description": "Added missing calls to `subscribe` in Admin Service methods that call the `closeReport` method. Since the method returns a cold observable, those `closeReport` requests weren't executed until a subscription was made to the observable, which means reports weren't closed in those workflows."
+    }
+  ]
+}

--- a/changelog/pr1602.json
+++ b/changelog/pr1602.json
@@ -16,6 +16,10 @@
     {
       "change": "Fixes",
       "description": "Added missing calls to `subscribe` in Admin Service methods that call the `closeReport` method. Since the method returns a cold observable, those `closeReport` requests weren't executed until a subscription was made to the observable, which means reports weren't closed in those workflows."
+    },
+    {
+      "change": "Changes",
+      "description": "Adjusted the way reports are closed when it's done via the 'edit display name' form. Previously, the 'edit user' request made to the back-end included a key that included the ID of the report to close. Now, the two requests are separated - once the user has been updated, the Admin Service makes the request to close the report."
     }
   ]
 }

--- a/src/app/components/adminReports/adminReports.component.html
+++ b/src/app/components/adminReports/adminReports.component.html
@@ -45,7 +45,7 @@
       (click)="prevPage('users')"
       aria-label="previous page of user reports"
     >Previous Page</button>
-    <div class="pageCount">Page {{ currentUserReportsPage }} of {{ totalUserReportsPages }}</div>
+    <div class="pageCount">Page {{ currentUserReportsPage() }} of {{ totalUserReportsPages() }}</div>
     <button
       [ngClass]="usersNextButtonClass()"
       [disabled]="totalUserReportsPages() <= currentUserReportsPage()"

--- a/src/app/components/adminReports/adminReports.component.html
+++ b/src/app/components/adminReports/adminReports.component.html
@@ -114,7 +114,7 @@
 <display-name-edit-form
   *ngIf="nameEditMode"
   [editedItem]="toEdit"
-  [toEdit]="editType"
+  [reportData]="reportData"
   (editMode)="changeMode($event, 'EditName')"
 ></display-name-edit-form>
 
@@ -122,11 +122,14 @@
 	*ngIf="deleteMode"
 	(editMode)="changeMode($event, 'Delete')"
 	[toDelete]="toDelete"
+  [reportData]="reportData"
 	[itemToDelete]="itemToDelete"
 ></item-delete-form>
 
 <post-edit-form
 	*ngIf="postEditMode"
 	[editedItem]="toEdit"
+  [reportData]="reportData"
+  [isAdmin]="true"
 	(editMode)="changeMode($event, 'EditPost')"
 ></post-edit-form>

--- a/src/app/components/adminReports/adminReports.component.spec.ts
+++ b/src/app/components/adminReports/adminReports.component.spec.ts
@@ -64,6 +64,7 @@ const mockUserReports: Report[] = [
     date: new Date("2020-06-29 19:17:31.072"),
     dismissed: false,
     closed: false,
+    displayName: "user",
   },
 ];
 const mockPostReports: Report[] = [
@@ -198,9 +199,12 @@ describe("AdminReports", () => {
     fixture.detectChanges();
 
     // check expectations
-    expect(editSpy).toHaveBeenCalled();
+    expect(editSpy).toHaveBeenCalledWith(1, 10, "user");
     expect(adminReports.nameEditMode).toBeTrue();
-    expect(adminReports.editType).toBe("other user");
+    expect(adminReports.toEdit).toEqual({
+      displayName: "user",
+      id: 10,
+    });
     expect(adminReportsDOM.querySelector("app-pop-up")).toBeTruthy();
     done();
   });
@@ -230,7 +234,6 @@ describe("AdminReports", () => {
     // check expectations
     expect(editSpy).toHaveBeenCalled();
     expect(adminReports.postEditMode).toBeTrue();
-    expect(adminReports.editType).toBe("admin post");
     expect(adminReportsDOM.querySelector("app-pop-up")).toBeTruthy();
     done();
   });
@@ -425,8 +428,10 @@ describe("AdminReports", () => {
 
     // start the popup
     adminReports.lastFocusedElement = document.querySelectorAll("a")[0];
-    adminReports.editType = "other user";
-    adminReports.toEdit = "displayName";
+    adminReports.toEdit = {
+      displayName: "displayName",
+      id: 2,
+    };
     adminReports.nameEditMode = true;
     adminReports.reportData.reportID = 5;
     adminReports.reportData.userID = 2;
@@ -454,7 +459,6 @@ describe("AdminReports", () => {
 
     // start the popup
     adminReports.lastFocusedElement = document.querySelectorAll("a")[0];
-    adminReports.editType = "admin post";
     adminReports.toEdit = "post";
     adminReports.postEditMode = true;
     adminReports.reportData.reportID = 5;

--- a/src/app/components/adminReports/adminReports.component.ts
+++ b/src/app/components/adminReports/adminReports.component.ts
@@ -54,7 +54,6 @@ export class AdminReports {
   isLoading = false;
   // edit popup sub-component variables
   toEdit: any;
-  editType: string | undefined;
   nameEditMode: boolean = false;
   postEditMode: boolean = false;
   reportData: {
@@ -143,8 +142,10 @@ export class AdminReports {
   */
   editUser(reportID: number, userID: number, displayName: string) {
     this.lastFocusedElement = document.activeElement;
-    this.editType = "other user";
-    this.toEdit = displayName;
+    this.toEdit = {
+      displayName,
+      id: userID,
+    };
     this.nameEditMode = true;
     this.reportData.reportID = reportID;
     this.reportData.userID = userID;
@@ -161,7 +162,6 @@ export class AdminReports {
   */
   editPost(postID: number, postText: string, reportID: number) {
     this.lastFocusedElement = document.activeElement;
-    this.editType = "admin post";
     this.toEdit = { text: postText, id: postID };
     this.postEditMode = true;
     this.reportData.reportID = reportID;

--- a/src/app/components/forms/displayNameEditForm/displayNameEditForm.component.html
+++ b/src/app/components/forms/displayNameEditForm/displayNameEditForm.component.html
@@ -15,7 +15,7 @@
   
     <!-- If the user is editing their own display name -->
     <button
-      *ngIf="toEdit == 'user'"
+      *ngIf="!reportData"
       type="submit"
       class="appButton updateItem"
       (click)="updateDisplayName($event, null)"
@@ -25,14 +25,14 @@
   
     <!-- If the user is editing another user -->
     <button
-      *ngIf="toEdit == 'other user'"
+      *ngIf="reportData"
       (click)="updateDisplayName($event, true)"
       type="submit"
       class="appButton updateItem">
         Update User and Close Report
     </button>
     <button
-      *ngIf="toEdit == 'other user'"
+      *ngIf="reportData"
       (click)="updateDisplayName($event, false)"
       type="submit"
       class="appButton updateItem">

--- a/src/app/components/forms/displayNameEditForm/displayNameEditForm.component.spec.ts
+++ b/src/app/components/forms/displayNameEditForm/displayNameEditForm.component.spec.ts
@@ -100,7 +100,7 @@ describe("DisplayNameEditForm", () => {
     };
     popUp.ngOnInit();
 
-    expect(popUp.editedItem.displayName).not.toEqual(popUp.authService.userData.displayName);
+    expect(popUp.editedItem.displayName).not.toEqual(popUp.authService.userData!.displayName);
   });
 
   it("should make the request to authService to change the name", () => {

--- a/src/app/components/forms/displayNameEditForm/displayNameEditForm.component.spec.ts
+++ b/src/app/components/forms/displayNameEditForm/displayNameEditForm.component.spec.ts
@@ -84,18 +84,23 @@ describe("DisplayNameEditForm", () => {
   it("should set editedItem depending on toEdit", () => {
     const fixture = TestBed.createComponent(DisplayNameEditForm);
     const popUp = fixture.componentInstance;
-    popUp.toEdit = "user";
+    popUp.editedItem = {
+      id: 4,
+      displayName: "name",
+    };
     popUp.ngOnInit();
 
     expect(popUp.editNameForm.controls.newDisplayName.value).toEqual(
       popUp.authService.userData.displayName,
     );
 
-    popUp.toEdit = "other user";
-    popUp.editedItem = "test";
+    popUp.editedItem = {
+      displayName: "test",
+      id: 1,
+    };
     popUp.ngOnInit();
 
-    expect(popUp.editedItem).toEqual("test");
+    expect(popUp.editedItem.displayName).not.toEqual(popUp.authService.userData.displayName);
   });
 
   it("should make the request to authService to change the name", () => {
@@ -107,15 +112,9 @@ describe("DisplayNameEditForm", () => {
     const fixture = TestBed.createComponent(DisplayNameEditForm);
     const popUp = fixture.componentInstance;
     const popUpDOM = fixture.nativeElement;
-    popUp.toEdit = "user";
     popUp.editedItem = {
       id: 4,
       displayName: "name",
-      receivedHugs: 2,
-      givenHugs: 2,
-      postsNum: 2,
-      loginCount: 3,
-      role: "admin",
     };
     const newName = "new name";
     fixture.detectChanges();
@@ -143,19 +142,13 @@ describe("DisplayNameEditForm", () => {
     const fixture = TestBed.createComponent(DisplayNameEditForm);
     const popUp = fixture.componentInstance;
     const popUpDOM = fixture.nativeElement;
-    popUp.toEdit = "other user";
     popUp.editedItem = {
-      id: 4,
+      id: 2,
       displayName: "name",
-      receivedHugs: 2,
-      givenHugs: 2,
-      postsNum: 2,
-      loginCount: 3,
-      role: "admin",
     };
     popUp.reportData = {
       reportID: 1,
-      userID: 4,
+      userID: 2,
     };
     const newName = "new name";
     fixture.detectChanges();
@@ -171,7 +164,7 @@ describe("DisplayNameEditForm", () => {
     expect(validateSpy).toHaveBeenCalledWith("displayName");
     expect(updateSpy).toHaveBeenCalledWith(
       {
-        userID: 4,
+        id: 2,
         displayName: newName,
       },
       true,
@@ -189,19 +182,13 @@ describe("DisplayNameEditForm", () => {
     const fixture = TestBed.createComponent(DisplayNameEditForm);
     const popUp = fixture.componentInstance;
     const popUpDOM = fixture.nativeElement;
-    popUp.toEdit = "other user";
     popUp.editedItem = {
-      id: 4,
+      id: 2,
       displayName: "name",
-      receivedHugs: 2,
-      givenHugs: 2,
-      postsNum: 2,
-      loginCount: 3,
-      role: "admin",
     };
     popUp.reportData = {
       reportID: 1,
-      userID: 4,
+      userID: 2,
     };
     const newName = "new name";
     fixture.detectChanges();
@@ -217,7 +204,7 @@ describe("DisplayNameEditForm", () => {
     expect(validateSpy).toHaveBeenCalledWith("displayName");
     expect(updateSpy).toHaveBeenCalledWith(
       {
-        userID: 4,
+        id: 2,
         displayName: newName,
       },
       false,
@@ -237,15 +224,9 @@ describe("DisplayNameEditForm", () => {
     const fixture = TestBed.createComponent(DisplayNameEditForm);
     const popUp = fixture.componentInstance;
     const popUpDOM = fixture.nativeElement;
-    popUp.toEdit = "user";
     popUp.editedItem = {
       id: 4,
       displayName: "name",
-      receivedHugs: 2,
-      givenHugs: 2,
-      postsNum: 2,
-      loginCount: 3,
-      role: "admin",
     };
     const newName = "new name";
     fixture.detectChanges();

--- a/src/app/components/forms/reportForm/reportForm.component.ts
+++ b/src/app/components/forms/reportForm/reportForm.component.ts
@@ -39,7 +39,6 @@ import { Post } from "@app/interfaces/post.interface";
 import { Report } from "@app/interfaces/report.interface";
 import { OtherUser } from "@app/interfaces/otherUser.interface";
 import { AuthService } from "@app/services/auth.service";
-import { ItemsService } from "@app/services/items.service";
 import { AlertsService } from "@app/services/alerts.service";
 import { ValidationService } from "@app/services/validation.service";
 import { ApiClientService } from "@app/services/apiClient.service";
@@ -93,7 +92,6 @@ export class ReportForm {
   // CTOR
   constructor(
     public authService: AuthService,
-    private itemsService: ItemsService,
     private alertsService: AlertsService,
     private validationService: ValidationService,
     private apiClient: ApiClientService,

--- a/src/app/components/userPage/userPage.component.html
+++ b/src/app/components/userPage/userPage.component.html
@@ -86,6 +86,5 @@
 <display-name-edit-form
 	*ngIf="editMode"
 	[editedItem]="userToEdit"
-	[toEdit]="editType"
 	(editMode)="changeMode($event, 'Edit')"
 ></display-name-edit-form>

--- a/src/app/components/userPage/userPage.component.spec.ts
+++ b/src/app/components/userPage/userPage.component.spec.ts
@@ -421,8 +421,8 @@ describe("UserPage", () => {
     // after the click
     expect(userPage.editMode).toBeTrue();
     expect(userPage.userToEdit).toEqual({
-      displayName: userPage.authService.userData.displayName,
-      id: userPage.authService.userData.id as number,
+      displayName: userPage.authService.userData!.displayName,
+      id: userPage.authService.userData!.id as number,
     });
     expect(userPageDOM.querySelector("app-pop-up")).toBeTruthy();
     done();
@@ -559,8 +559,8 @@ describe("UserPage", () => {
     // start the popup
     userPage.lastFocusedElement = document.querySelectorAll("a")[0];
     userPage.userToEdit = {
-      displayName: userPage.authService.userData.displayName,
-      id: userPage.authService.userData.id as number,
+      displayName: userPage.authService.userData!.displayName,
+      id: userPage.authService.userData!.id as number,
     };
     userPage.editMode = true;
     fixture.detectChanges();

--- a/src/app/components/userPage/userPage.component.spec.ts
+++ b/src/app/components/userPage/userPage.component.spec.ts
@@ -408,7 +408,10 @@ describe("UserPage", () => {
 
     // after the click
     expect(userPage.editMode).toBeTrue();
-    expect(userPage.editType).toBe("user");
+    expect(userPage.userToEdit).toEqual({
+      displayName: userPage.authService.userData.displayName,
+      id: userPage.authService.userData.id as number,
+    });
     expect(userPageDOM.querySelector("app-pop-up")).toBeTruthy();
     done();
   });
@@ -535,9 +538,11 @@ describe("UserPage", () => {
 
     // start the popup
     userPage.lastFocusedElement = document.querySelectorAll("a")[0];
-    userPage.userToEdit = userPage.authService.userData;
+    userPage.userToEdit = {
+      displayName: userPage.authService.userData.displayName,
+      id: userPage.authService.userData.id as number,
+    };
     userPage.editMode = true;
-    userPage.editType = "user";
     fixture.detectChanges();
 
     // exit the popup

--- a/src/app/components/userPage/userPage.component.ts
+++ b/src/app/components/userPage/userPage.component.ts
@@ -38,7 +38,7 @@ import { faGratipay } from "@fortawesome/free-brands-svg-icons";
 import { HttpErrorResponse } from "@angular/common/http";
 
 // App-related imports
-import { User } from "@app/interfaces/user.interface";
+import { PartialUser, User } from "@app/interfaces/user.interface";
 import { AuthService } from "@app/services/auth.service";
 import { iconElements } from "@app/interfaces/types";
 import { OtherUser } from "@app/interfaces/otherUser.interface";
@@ -68,8 +68,7 @@ export class UserPage implements OnInit, OnDestroy, AfterViewChecked {
   });
   isOtherUserProfile = computed(() => this.otherUser() != undefined);
   // edit popup sub-component variables
-  userToEdit: any;
-  editType: string | undefined;
+  userToEdit?: PartialUser;
   editMode: boolean = false;
   reportMode: boolean = false;
   reportedItem: User | undefined;
@@ -237,9 +236,11 @@ export class UserPage implements OnInit, OnDestroy, AfterViewChecked {
   */
   editName() {
     this.lastFocusedElement = document.activeElement;
-    this.userToEdit = this.authService.userData;
+    this.userToEdit = {
+      displayName: this.displayUser().displayName,
+      id: this.displayUser().id as number,
+    };
     this.editMode = true;
-    this.editType = "user";
   }
 
   /*

--- a/src/app/interfaces/report.interface.ts
+++ b/src/app/interfaces/report.interface.ts
@@ -40,6 +40,7 @@ export interface Report {
   date: Date;
   dismissed: boolean;
   closed: boolean;
+  displayName?: string;
 }
 
 export interface ReportData {

--- a/src/app/interfaces/report.interface.ts
+++ b/src/app/interfaces/report.interface.ts
@@ -41,3 +41,8 @@ export interface Report {
   dismissed: boolean;
   closed: boolean;
 }
+
+export interface ReportData {
+  userID: number;
+  reportID: number;
+}

--- a/src/app/interfaces/user.interface.ts
+++ b/src/app/interfaces/user.interface.ts
@@ -58,3 +58,8 @@ export interface User {
   selectedIcon: iconCharacters;
   iconColours: UserIconColours;
 }
+
+export interface PartialUser {
+  id: number;
+  displayName: string;
+}

--- a/src/app/services/admin.service.spec.ts
+++ b/src/app/services/admin.service.spec.ts
@@ -82,7 +82,22 @@ describe("AdminService", () => {
       userID: 2,
     };
     const alertSpy = spyOn(adminService["alertsService"], "createSuccessAlert");
-    const dismissSpy = spyOn(adminService, "closeReport");
+    const dismissSpy = spyOn(adminService, "closeReport").and.returnValue(
+      of({
+        success: true,
+        updated: {
+          id: 1,
+          type: "User",
+          userID: 15,
+          displayName: "name",
+          reporter: 3,
+          reportReason: "reason",
+          date: new Date(),
+          dismissed: true,
+          closed: true,
+        },
+      }),
+    );
     const messageSpy = spyOn(adminService["itemsService"], "sendMessage");
     const deleteSWSpy = spyOn(adminService["serviceWorkerM"], "deleteItem");
     const deleteAPISpy = spyOn(adminService["apiClient"], "delete").and.returnValue(
@@ -112,7 +127,7 @@ describe("AdminService", () => {
     };
 
     const userData = {
-      userID: 2,
+      id: 2,
       displayName: "user",
     };
     const alertSpy = spyOn(adminService["alertsService"], "createSuccessAlert");
@@ -231,7 +246,22 @@ describe("AdminService", () => {
     const calculateSpy = spyOn(adminService, "calculateUserReleaseDate").and.returnValue(blockDate);
     const patchSpy = spyOn(adminService["apiClient"], "patch").and.returnValue(of(mockResponse));
     const alertSpy = spyOn(adminService["alertsService"], "createSuccessAlert");
-    const dismissSpy = spyOn(adminService, "closeReport");
+    const dismissSpy = spyOn(adminService, "closeReport").and.returnValue(
+      of({
+        success: true,
+        updated: {
+          id: 1,
+          type: "User",
+          userID: 15,
+          displayName: "name",
+          reporter: 3,
+          reportReason: "reason",
+          date: new Date(),
+          dismissed: true,
+          closed: true,
+        },
+      }),
+    );
 
     adminService.blockUser(15, "oneDay", 3);
 

--- a/src/app/services/admin.service.ts
+++ b/src/app/services/admin.service.ts
@@ -102,7 +102,7 @@ export class AdminService {
 
         // if the report needs to be closed
         if (closeReport) {
-          this.closeReport(reportData.reportID, false, postID);
+          this.closeReport(reportData.reportID, false, postID).subscribe({});
         }
 
         // delete the post from idb
@@ -259,7 +259,7 @@ export class AdminService {
           );
           // if the block was done via the reports page, also dismiss the report
           if (reportID) {
-            this.closeReport(reportID, false, undefined, userID);
+            this.closeReport(reportID, false, undefined, userID).subscribe({});
           }
         },
       });

--- a/src/app/services/admin.service.ts
+++ b/src/app/services/admin.service.ts
@@ -43,6 +43,7 @@ import { ItemsService } from "@app/services/items.service";
 import { SWManager } from "@app/services/sWManager.service";
 import { ApiClientService } from "@app/services/apiClient.service";
 import { OtherUser } from "@app/interfaces/otherUser.interface";
+import { PartialUser } from "@app/interfaces/user.interface";
 
 interface UserBlockData {
   userID: number;
@@ -124,18 +125,18 @@ export class AdminService {
   ----------------
   Programmer: Shir Bar Lev.
   */
-  editUser(user: any, closeReport: boolean, reportID: number) {
-    // if the report should be closed
-    if (closeReport) {
-      user["closeReport"] = reportID;
-    }
-
+  editUser(user: PartialUser, closeReport: boolean, reportID: number) {
     // update the user's display name
-    this.apiClient.patch(`users/all/${user.userID}`, user).subscribe({
+    this.apiClient.patch(`users/all/${user.id}`, user).subscribe({
       next: (response: any) => {
         this.alertsService.createSuccessAlert(`User ${response.updated.displayName} updated.`, {
           reload: closeReport,
         });
+
+        // if the report should be closed
+        if (closeReport) {
+          this.closeReport(reportID, false, undefined, user.id).subscribe({});
+        }
       },
     });
   }


### PR DESCRIPTION
**Description**

Previously, the display name edit form relied on being provided the type of item being edited ("admin user" / "user") in order to check where to fetch the name to display in the edit form from. This was unintuitive and added extra unnecessary complication.

**Issue link**

--

**Expected behavior**

--

**Your solution**

Standardised the inputs to the Display Name Edit Form and moved the check for current user vs admin edit. Now, both the user page and the reports page pass in an object with the ID and name of the user to edit. If the ID matches the ID in the Auth Service, the Auth Service is called to update the user's data; otherwise, the Admin Service is called.

**Additional information**

--