### PR TITLE
fix: The sitemap doesn't show the admin routes on refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Added missing calls to `subscribe` in Admin Service methods that call the `closeReport` method. Since the method returns a cold observable, those `closeReport` requests weren't executed until a subscription was made to the observable, which means reports weren't closed in those workflows. ([#1602](https://github.com/sendahug/send-hug-frontend/pull/1602))
 - Added the missing reportData input to all forms in the Admin Reports component. This fixes an error that caused the forms to ignore attempts to close reports when editing posts and users and when deleting posts. ([#1602](https://github.com/sendahug/send-hug-frontend/pull/1602))
-- Fixed a bug where the Admin Reports' report list accidentally showed `singal` instead of the current page and total page values. ([#1602](https://github.com/sendahug/send-hug-frontend/pull/1602))
+- Fixed a bug where the Admin Reports' report list accidentally showed `signal` instead of the current page and total page values. ([#1602](https://github.com/sendahug/send-hug-frontend/pull/1602))
 
 ### 2024-04-12
 

--- a/changelog/pr1608.json
+++ b/changelog/pr1608.json
@@ -1,5 +1,5 @@
 {
-  "pr_number": 0,
+  "pr_number": 1608,
   "changes": [
     {
       "change": "Fixes",

--- a/changelog/pr1608.json
+++ b/changelog/pr1608.json
@@ -1,0 +1,13 @@
+{
+  "pr_number": 0,
+  "changes": [
+    {
+      "change": "Fixes",
+      "description": "Fixed a bug where the sitemap hid the admin routes when users refreshed the page, even if they had permission to view it. This happened as a result of the re-authentication process (which runs automatically when the page is refreshed) took longer than it took to set up the component and the sitemap was only built when the component was set up. Now, if the user isn't authenticated 'yet', the component shows the unauthenticated routes but subscribes to the subject indicating whether the user is authenticated, and once they're authenticated, the component rebuilds the list of available paths."
+    },
+    {
+      "change": "Changes",
+      "description": "Removed the user, messages and settings routes from the displayed routes in the site map if the user isn't authenticated. Instead of these routes, the user is now shown the login route. This matches the behaviour of the main navigation menu."
+    }
+  ]
+}

--- a/src/app/components/siteMap/siteMap.component.spec.ts
+++ b/src/app/components/siteMap/siteMap.component.spec.ts
@@ -48,6 +48,7 @@ import { SiteMap } from "./siteMap.component";
 import { NotificationsTab } from "../notifications/notifications.component";
 import { AuthService } from "../../services/auth.service";
 import { AppAlert } from "../appAlert/appAlert.component";
+import { mockAuthedUser } from "@tests/mockData";
 
 // Mock Component for testing the sitemap
 // ==================================================
@@ -107,6 +108,7 @@ export const routes: Routes = [
     ],
     data: { name: "Mailbox" },
   },
+  { path: "login", component: MockComp, data: { name: "Login Page" } },
 ];
 
 describe("SiteMap", () => {
@@ -161,7 +163,9 @@ describe("SiteMap", () => {
 
   // Check that the admin board links are shown if the user has permission
   it("should show admin board links if the user has permission", () => {
-    const authSpy = spyOn(TestBed.inject(AuthService), "canUser").and.returnValue(true);
+    const authService = TestBed.inject(AuthService);
+    const authSpy = spyOn(authService, "canUser").and.returnValue(true);
+    authService.authenticated.set(true);
     TestBed.createComponent(AppComponent);
     const fixture = TestBed.createComponent(SiteMap);
     const siteMap = fixture.componentInstance;
@@ -203,7 +207,9 @@ describe("SiteMap", () => {
 
   // Check that the admin board links aren't shown if the user doesn't have permission
   it("should hide admin board links if the user doesn't have permission", () => {
-    const authSpy = spyOn(TestBed.inject(AuthService), "canUser").and.returnValue(false);
+    const authService = TestBed.inject(AuthService);
+    const authSpy = spyOn(authService, "canUser").and.returnValue(false);
+    authService.authenticated.set(true);
     TestBed.createComponent(AppComponent);
     const fixture = TestBed.createComponent(SiteMap);
     const siteMap = fixture.componentInstance;
@@ -249,7 +255,9 @@ describe("SiteMap", () => {
 
   // Check that the first and last messages routes are removed
   it("should remove the first and last children of the messages route", () => {
-    spyOn(TestBed.inject(AuthService), "canUser").and.returnValue(false);
+    const authService = TestBed.inject(AuthService);
+    spyOn(authService, "canUser").and.returnValue(false);
+    authService.authenticated.set(true);
     TestBed.createComponent(AppComponent);
     const fixture = TestBed.createComponent(SiteMap);
     const siteMap = fixture.componentInstance;
@@ -296,7 +304,9 @@ describe("SiteMap", () => {
 
   // Check that the last route is removed from user routes
   it("should remove the last child of the user route", () => {
-    spyOn(TestBed.inject(AuthService), "canUser").and.returnValue(false);
+    const authService = TestBed.inject(AuthService);
+    spyOn(authService, "canUser").and.returnValue(false);
+    authService.authenticated.set(true);
     TestBed.createComponent(AppComponent);
     const fixture = TestBed.createComponent(SiteMap);
     const siteMap = fixture.componentInstance;
@@ -333,6 +343,83 @@ describe("SiteMap", () => {
     expect(siteMap.routes).toContain(userPath);
     for (var i = 0; i < navLinks.length; i++) {
       expect(navLinks[i].textContent).not.toBe("Other User's Page");
+    }
+  });
+
+  it("should remove the login route if the user is authenticated", () => {
+    const authService = TestBed.inject(AuthService);
+    spyOn(authService, "authenticated").and.returnValue(true);
+    TestBed.createComponent(AppComponent);
+    const fixture = TestBed.createComponent(SiteMap);
+    const siteMap = fixture.componentInstance;
+    const siteMapDOM = fixture.nativeElement;
+    fixture.detectChanges();
+
+    let routeList = siteMapDOM.querySelector("#routeList");
+    let navLinks = routeList!.querySelectorAll(".routerLink");
+    let loginPath: Route = { path: "login", component: MockComp, data: { name: "Login Page" } };
+
+    expect(siteMap.routes).not.toContain(loginPath);
+    for (var i = 0; i < navLinks.length; i++) {
+      expect(navLinks[i].textContent).not.toBe("Login Page");
+    }
+  });
+
+  it("should keep the login route if the user is not authenticated", () => {
+    const authService = TestBed.inject(AuthService);
+    spyOn(authService, "authenticated").and.returnValue(false);
+    TestBed.createComponent(AppComponent);
+    const fixture = TestBed.createComponent(SiteMap);
+    const siteMap = fixture.componentInstance;
+    const siteMapDOM = fixture.nativeElement;
+    fixture.detectChanges();
+
+    let routeList = siteMapDOM.querySelector("#routeList");
+    let navLinks = routeList!.querySelectorAll(".routerLink");
+    let loginPath: Route = { path: "login", component: MockComp, data: { name: "Login Page" } };
+
+    expect(siteMap.routes).toContain(loginPath);
+    expect(navLinks[navLinks.length - 1].textContent).toBe("Login Page");
+  });
+
+  it("should update the site map if the user authenticates after the component is created", () => {
+    const authService = TestBed.inject(AuthService);
+    authService.authenticated.set(false);
+    TestBed.createComponent(AppComponent);
+    const fixture = TestBed.createComponent(SiteMap);
+    const siteMap = fixture.componentInstance;
+    const siteMapDOM = fixture.nativeElement;
+    fixture.detectChanges();
+
+    let routeList = siteMapDOM.querySelector("#routeList");
+    let navLinks = routeList!.querySelectorAll(".routerLink");
+    let loginPath: Route = { path: "login", component: MockComp, data: { name: "Login Page" } };
+    let userPath: Route = {
+      path: "user",
+      children: [
+        { path: "", pathMatch: "prefix", component: MockComp, data: { name: "Your Page" } },
+      ],
+      data: { name: "User Page" },
+    };
+
+    expect(siteMap.routes).toContain(loginPath);
+    expect(siteMap.routes).not.toContain(userPath);
+    expect(navLinks[navLinks.length - 1].textContent).toBe("Login Page");
+    for (var i = 0; i < navLinks.length; i++) {
+      expect(navLinks[i].textContent).not.toBe(userPath.children![0].data!.name);
+    }
+
+    authService.authenticated.set(true);
+    authService.userData = { ...mockAuthedUser };
+    authService.isUserDataResolved.next(true);
+    fixture.detectChanges();
+
+    navLinks = routeList!.querySelectorAll(".routerLink");
+    expect(siteMap.routes).not.toContain(loginPath);
+    expect(siteMap.routes).toContain(userPath);
+    expect(navLinks[1].textContent).toBe(userPath.children![0].data!.name);
+    for (var i = 0; i < navLinks.length; i++) {
+      expect(navLinks[i].textContent).not.toBe(loginPath.data!.name);
     }
   });
 });

--- a/src/app/components/siteMap/siteMap.component.ts
+++ b/src/app/components/siteMap/siteMap.component.ts
@@ -96,6 +96,8 @@ export class SiteMap {
           }
         } else if (route.path == "login") {
           if (!this.authService.authenticated()) this.routes.push(route);
+        } else if (route.path == "settings") {
+          if (this.authService.authenticated()) this.routes.push(route);
         }
         // otherwise just add the route as-is
         else {

--- a/src/app/components/siteMap/siteMap.component.ts
+++ b/src/app/components/siteMap/siteMap.component.ts
@@ -49,6 +49,25 @@ export class SiteMap {
     private router: Router,
     private authService: AuthService,
   ) {
+    this.updateSiteMap();
+
+    if (!this.authService.authenticated()) {
+      const userSubscription = this.authService.isUserDataResolved.subscribe((value) => {
+        if (value) {
+          this.updateSiteMap();
+          userSubscription.unsubscribe();
+        }
+      });
+    }
+  }
+
+  /**
+   * Updates the site map based on the user's permissions and whether they're
+   * logged in.
+   */
+  updateSiteMap() {
+    this.routes.splice(0, this.routes.length);
+
     this.router.config.forEach((route) => {
       // make sure the path isn't the error page or the search results
       if (route.path != "**" && route.path != "search") {
@@ -61,16 +80,22 @@ export class SiteMap {
         // if it's the mailbox component, remove the first child path, as it's a
         // redirect, and remove the last one, as it requires a parameter
         else if (route.path!.includes("messages")) {
-          const fixedRoute = route;
-          fixedRoute.children!.shift();
-          fixedRoute.children!.pop();
-          this.routes.push(fixedRoute);
+          if (this.authService.authenticated()) {
+            const fixedRoute = route;
+            fixedRoute.children!.shift();
+            fixedRoute.children!.pop();
+            this.routes.push(fixedRoute);
+          }
         }
         // if it's the user page, show just the user's own page, as it requires a parameter
         else if (route.path!.includes("user")) {
-          const fixedRoute = route;
-          fixedRoute.children!.pop();
-          this.routes.push(fixedRoute);
+          if (this.authService.authenticated()) {
+            const fixedRoute = route;
+            fixedRoute.children!.pop();
+            this.routes.push(fixedRoute);
+          }
+        } else if (route.path == "login") {
+          if (!this.authService.authenticated()) this.routes.push(route);
         }
         // otherwise just add the route as-is
         else {


### PR DESCRIPTION
**Description**

When refreshing the sitemap, the map doesn't include the admin routes, even if the user has permission to use it.

**Issue link**

--

**Expected behavior**

The site map should be updated to include the admin routes.

**Your solution**

The site map now subscribes to the `isUserDataResolved` property of the AuthService if that user isn't already authenticated. Once the app finishes its authentication process, the site map is updated and the subscription is cancelled.

**Additional information**

--
