### PR TITLE
chore: Updated the 'copy static assets' Gulp tasks.

### DIFF
--- a/changelog/pr1615.json
+++ b/changelog/pr1615.json
@@ -1,0 +1,9 @@
+{
+  "pr_number": 1615,
+  "changes": [
+    {
+      "change": "Chores",
+      "description": "Updated the syntax of the gulp tasks which copy static assets to the new Gulp 5 syntax. This also fixes a bug where the PNG icons (used in our webmanifest) were copied as invalid photos (see [the relevant Gulp issue](https://github.com/gulpjs/gulp/issues/2766) for explanation)."
+    }
+  ]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ function copyIndex()
 function copyAssets()
 {
   return gulp
-    .src("src/assets/**/*")
+    .src("src/assets/**/*", { encoding: false })
     .pipe(gulp.dest("localdev/assets/"));
 }
 
@@ -219,7 +219,7 @@ function copyIndexDist()
 function copyAssetsDist()
 {
   return gulp
-    .src("src/assets/**/*")
+    .src("src/assets/**/*", { encoding: false })
     .pipe(gulp.dest("dist/assets/"));
 }
 


### PR DESCRIPTION
See https://github.com/gulpjs/gulp/issues/2766.