### PR TITLE
chore: Move script compilation from @rollup/stream to plain rollup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,13 +8,11 @@ coverage
 .DS_Store
 
 # local development files
-localdev/app
-localdev/css
-localdev/app.bundle.js
-localdev/app.bundle.js.map
-localdev/index.html
-localdev/assets/*
-localdev/manifest.webmanifest
+localdev/*
+# TODO: These should really be moved to the src folder
+!localdev/favicon.ico
+!localdev/sitemap.xml
+!localdev/sw.js
 
 # Testing files
 src/tests.specs.ts

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The project is open source, so feel free to use parts of the code. However, the 
 2. cd into the project directory.
 3. Run `git config core.hooksPath .githooks` to install the pre-commit hook, which runs prettier.
 4. Run `npm install` to install dependencies.
-5. Run `gulp localdev` to compile the whole project for local development.
+5. Run `npm run localdev` to compile the whole project for local development.
 6. Run `gulp serve` to start the local server.
 7. Open localhost:3000.
 

--- a/changelog/pr1618.json
+++ b/changelog/pr1618.json
@@ -1,0 +1,13 @@
+{
+  "pr_number": 1618,
+  "changes": [
+    {
+      "change": "Chores",
+      "description": "Replaced @rollup/stream with rollup in the process of bundling the site's scripts. Since @rollup/stream is the recommended plugin for making rollup work with gulp, we've been using it in script compilation. However, @rollup/stream doesn't support chunking, and the process of using it with gulp produces considerably larger JavaScript bundles than rollup itself. Moving to rollup allows us to generate smaller packages, and, in the future, it will allow us to start splitting the code. The change includes:\n\t- Added a new rollup configuration file.\n\t- Converted the old processor CommonJS file (with the rollup plugins we use in compilation and in tests) to an ES module with the plugins we use.\n\t- The gulp tasks for bundling the scripts now run rollup via a child process (Node.js's `exec`) instead of running @rollup/stream."
+    },
+    {
+      "change": "Chores",
+      "description": "Combined the rollup plugin for setting the environment to production with the rollup plugin for replacing the environment variables. Since they both update the environment variables and the production environment setter now consists of one line of code, there was no need to keep them separated."
+    }
+  ]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,27 +6,13 @@ const gulp = require("gulp");
 const postcss = require("gulp-postcss");
 const rename = require("gulp-rename");
 const replace = require("gulp-replace");
-const source = require("vinyl-source-stream");
-const buffer = require("vinyl-buffer");
 const less = require('gulp-less');
-// rollup deps
-const rollupStream = require("@rollup/stream");
-const commonjs = require("@rollup/plugin-commonjs");
-const nodeResolve = require("@rollup/plugin-node-resolve").nodeResolve;
-const typescript = require("@rollup/plugin-typescript");
-const terser = require('@rollup/plugin-terser');
 // everything else
 const autoprefixer = require("autoprefixer");
 const browserSync = require("browser-sync").create();
 const Server = require('karma').Server;
 const parseConfig = require('karma').config.parseConfig;
 const glob = require("glob");
-// internal plugins
-const {
-  setProductionEnv,
-  updateComponentTemplateUrl,
-  updateEnvironmentVariables
-} = require("./processor");
 
 let bs;
 
@@ -98,30 +84,11 @@ function styles()
 }
 
 //deals with transforming the scripts while in development mode
-function scripts()
+async function scripts()
 {
-  const options = {
-     input: 'src/main.ts',
-     output: { sourcemap: 'inline' },
-     plugins: [
-      updateEnvironmentVariables("development"),
-      updateComponentTemplateUrl(),
-       typescript({ exclude: ['**/*.spec.ts', 'e2e/**/*'] }),
-       nodeResolve({
-         extensions: ['.js', '.ts']
-       }),
-       commonjs({
-         extensions: ['.js', '.ts'],
-         transformMixedEsModules: true
-       })
-       ]
-      };
-
-   return rollupStream(options)
-      .pipe(source("src/main.ts"))
-      .pipe(buffer())
-      .pipe(rename("app.bundle.js"))
-      .pipe(gulp.dest("./localdev"));
+  // A bit hacky, but worth it considering the massive size improvement
+  // rollup provides vs @rollup/stream
+  await exec("npm run rollup:dev");
 }
 
 // copy webmanifest
@@ -234,35 +201,11 @@ function stylesDist()
 }
 
 //deals with transforming and bundling the scripts while in production mode
-function scriptsDist()
+async function scriptsDist()
 {
-  const options = {
-    input: 'src/main.ts',
-    output: {
-      file: "app.bundle.min.js",
-      sourcemap: 'hidden',
-      plugins: [terser()]
-    },
-    plugins: [
-      updateEnvironmentVariables("live"),
-      setProductionEnv(),
-      updateComponentTemplateUrl(),
-      typescript({ exclude: ['**/*.spec.ts', 'e2e/**/*'] }),
-      nodeResolve({
-        extensions: ['.js', '.ts']
-      }),
-      commonjs({
-        extensions: ['.js', '.ts'],
-        transformMixedEsModules: true
-      })
-      ]
-     };
-
-  return rollupStream(options)
-      .pipe(source("src/main.ts"))
-      .pipe(buffer())
-      .pipe(rename("app.bundle.min.js"))
-      .pipe(gulp.dest("./dist"));
+  // A bit hacky, but worth it considering the massive size improvement
+  // rollup provides vs @rollup/stream
+  await exec("npm run rollup:live");
 }
 
 //copy the service worker to the distribution folder; update the cache version on each build

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -175,10 +175,6 @@ function copyIndexDist()
 {
   return gulp
     .src("index.html")
-    .pipe(replace(/src="app.bundle.js"/, () => {
-      let newString = `src="app.bundle.min.js"`
-      return newString;
-    }))
     .pipe(gulp.dest("./dist"));
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,7 +88,15 @@ async function scripts()
 {
   // A bit hacky, but worth it considering the massive size improvement
   // rollup provides vs @rollup/stream
-  await exec("npm run rollup:dev");
+  await exec("npm run rollup:dev", (error, stdout, stderr) => {
+    if (error) {
+       console.log(`error: ${error.message}`);
+    }
+    if (stderr) {
+       console.log(`stderr: ${stderr}`);
+    }
+    console.log(`stdout: ${stdout}`);
+  });
 }
 
 // copy webmanifest

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,8 @@
 const path = require("path");
+// TODO: Figure out how to avoid defining the same module TWICE
+// However, seems like Karma doesn't like ESM and since it's deprecated
+// it's unlikely to get an update to fix that:
+// https://github.com/karma-runner/karma/issues/3677
 const { inlineComponentTemplate, inlineSVGs, updateEnvironmentVariables } = require("./processor");
 const coverage = require("rollup-plugin-istanbul");
 const commonjs = require("@rollup/plugin-commonjs");

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.6",
-        "@rollup/stream": "^3.0.1",
         "@types/auth0-js": "^9.21.5",
         "@types/jasmine": "^5.1.4",
         "@types/node": "^20.12.7",
@@ -1232,18 +1231,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@rollup/stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/stream/-/stream-3.0.1.tgz",
-      "integrity": "sha512-wdzoakLc9UiPOFa1k17ukfEtvQ0p7JuNFvOZT1DhO5Z5CrTf71An01U9+v+aebYcaLCwy3tLwpCSUF7K7xVN0A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.35.1||^3.0.0||^4.0.0"
-      }
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "cypress": "cypress run",
     "e2e": "gulp e2e",
     "build": "gulp dist",
-    "start": "node server.js"
+    "start": "node server.js",
+    "rollup:dev": "rollup --config --mode development",
+    "rollup:live": "rollup --config"
   },
   "overrides": {
     "karma-jasmine": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "format": "prettier .  --write",
-    "compile:dev": "gulp localDev",
+    "localDev": "gulp localDev",
     "test": "gulp test",
     "cypress": "cypress run",
     "e2e": "gulp e2e",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
-    "@rollup/stream": "^3.0.1",
     "@types/auth0-js": "^9.21.5",
     "@types/jasmine": "^5.1.4",
     "@types/node": "^20.12.7",

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -1,0 +1,144 @@
+import MagicString from "magic-string";
+import fs from "fs";
+import dotenv from "dotenv";
+
+/**
+ * Rollup plugin that replaces the Angular templateUrl in test files with
+ * the inlined template. Originally written as a Browserify transform:
+ * https://github.com/shirblc/angular-gulp/pull/1
+ *
+ * Inspited by @rollup/plugin-replce
+ * https://github.com/rollup/plugins/blob/master/packages/replace/src/index.js
+ */
+export function inlineComponentTemplate() {
+  return {
+    name: "plugin-inline-template",
+    transform(code) {
+      const magicString = new MagicString(code);
+      const commonComponents = fs.readdirSync("./src/app/common/components");
+      const adminComponents = fs.readdirSync("./src/app/admin/components");
+      const userComponents = fs.readdirSync("./src/app/user/components");
+
+      magicString.replace(/(templateUrl:)(.*)(\.component\.html")/, (match) => {
+        const componentName = match.split(".")[1].substring(1);
+        if (componentName == "my") return match;
+        let componentTemplateURL;
+
+        if (componentName == "app") {
+          componentTemplateURL = __dirname + `/src/app/${componentName}.component.html`;
+        } else if (commonComponents.includes(componentName)) {
+          componentTemplateURL =
+            __dirname +
+            `/src/app/common/components/${componentName}/${componentName}.component.html`;
+        } else if (adminComponents.includes(componentName)) {
+          componentTemplateURL =
+            __dirname +
+            `/src/app/admin/components/${componentName}/${componentName}.component.html`;
+        } else if (userComponents.includes(componentName)) {
+          componentTemplateURL =
+            __dirname + `/src/app/user/components/${componentName}/${componentName}.component.html`;
+        } else {
+          componentTemplateURL =
+            __dirname + `/src/app/components/${componentName}/${componentName}.component.html`;
+        }
+
+        componentTemplate = fs.readFileSync(componentTemplateURL);
+
+        return `template: \`${componentTemplate}\``;
+      });
+
+      return {
+        code: magicString.toString(),
+        map: magicString.generateMap(),
+      };
+    },
+  };
+}
+
+/**
+ * Rollup plugin for inlining the SVGs.
+ * Originally written as a Browserify transform:
+ * https://github.com/sendahug/send-hug-frontend/commit/d0cb971da5801ebfecb05184d09386e743b7405b
+ */
+export function inlineSVGs() {
+  return {
+    name: "inliner",
+    transform(code) {
+      const magicString = new MagicString(code);
+
+      // inline the SVGs
+      magicString.replace(/(<img src="..\/assets.)(.*)(.">)/g, (match) => {
+        const altIndex = match.indexOf("alt");
+        const url = match.substring(13, altIndex - 2);
+        const svg = fs.readFileSync(__dirname + `/src/${url}`);
+
+        return `${svg}`;
+      });
+
+      return {
+        code: magicString.toString(),
+        map: magicString.generateMap(),
+      };
+    },
+  };
+}
+
+/**
+ * Updates the environment variables in the app based on
+ * the environment variables
+ */
+export function updateEnvironmentVariables(currentMode = "development") {
+  return {
+    name: "rollup-plugin-update-environment-variables",
+    transform(code) {
+      const magicString = new MagicString(code);
+
+      // Sets the angular environment to production.
+      // Originally written as a Browserify transform:
+      // https://github.com/sendahug/send-hug-frontend/blob/c783442236d07d4aa9d7439b3bc74e450bf4b5ec/gulpfile.js#L232
+      // And later updated to a rollup plugin:
+      // https://github.com/sendahug/send-hug-frontend/blob/0bb431d0a4f4cdba441d25d4dc9fa836f198ba93/processor.js#L91
+      if (currentMode != "development") {
+        magicString.replace(/environments\/environment/, "environments/environment.prod");
+      }
+
+      dotenv.config({
+        path: `./.env.${currentMode}`,
+      });
+
+      magicString.replaceAll(/process\.env\.(.+),/g, (match) => {
+        const envVar = match.split(".")[2].split(",")[0];
+        const value = process.env[envVar];
+        return `'${value}',`;
+      });
+
+      return {
+        code: magicString.toString(),
+        map: magicString.generateMap(),
+      };
+    },
+  };
+}
+
+/**
+ * Updates each component's template URL to the production
+ * structure.
+ */
+export function updateComponentTemplateUrl() {
+  return {
+    name: "plugin-template-updater",
+    transform(code) {
+      const magicString = new MagicString(code);
+
+      magicString.replace(/(templateUrl:)(.*)(\.component\.html")/, (match) => {
+        const componentName = match.split(".")[1].substring(1);
+        return `templateUrl: "./app/${componentName}.component.html"`;
+      });
+
+      return {
+        code: magicString.toString(),
+        map: magicString.generateMap(),
+      };
+    },
+  };
+}

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -26,6 +26,13 @@ export default (commandLineArgs) => {
         transformMixedEsModules: true,
       }),
     ],
+    onwarn(warning, warn) {
+      if (warning.code === "UNKNOWN_OPTION") {
+        // This allows using test flag
+        if (warning.message.includes("Unknown CLI flags: mode")) return;
+      }
+      warn(warning);
+    },
   };
 
   // Only run terser in production, as it's quite a long and expensive

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,0 +1,38 @@
+import commonjs from "@rollup/plugin-commonjs";
+import nodeResolve from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+import terser from "@rollup/plugin-terser";
+import { updateComponentTemplateUrl, updateEnvironmentVariables } from "./plugins.mjs";
+
+export default (commandLineArgs) => {
+  const currentMode = commandLineArgs.mode || "live";
+
+  let buildConfig = {
+    input: ["src/main.ts"],
+    output: {
+      sourcemap: currentMode == "development" ? "inline" : "hidden",
+      dir: currentMode == "development" ? "localdev" : "dist",
+      entryFileNames: currentMode == "development" ? "app.bundle.js" : "app.bundle.min.js",
+    },
+    plugins: [
+      updateEnvironmentVariables(currentMode),
+      updateComponentTemplateUrl(),
+      typescript({ exclude: ["**/*.spec.ts", "e2e/**/*"] }),
+      nodeResolve({
+        extensions: [".js", ".ts"],
+      }),
+      commonjs({
+        extensions: [".js", ".ts"],
+        transformMixedEsModules: true,
+      }),
+    ],
+  };
+
+  // Only run terser in production, as it's quite a long and expensive
+  // process.
+  if (currentMode != "development") {
+    buildConfig.output.plugins = [terser()];
+  }
+
+  return buildConfig;
+};

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -12,7 +12,7 @@ export default (commandLineArgs) => {
     output: {
       sourcemap: currentMode == "development" ? "inline" : "hidden",
       dir: currentMode == "development" ? "localdev" : "dist",
-      entryFileNames: currentMode == "development" ? "app.bundle.js" : "app.bundle.min.js",
+      entryFileNames: "app.bundle.js",
     },
     plugins: [
       updateEnvironmentVariables(currentMode),


### PR DESCRIPTION
**Description**

We've been using rollup/stream for script compilation, but apparently rollup/stream doesn't yet support chunking or multiple entry files (see https://github.com/rollup/stream/issues/13 and https://github.com/rollup/rollup/issues/4137). If we want to enable chunking, we need to use rollup itself.

**Issue link**

--

**Expected behavior**

--

**Your solution**

Switched the script compilation tasks to use rollup instead of the rollup/stream wrapper. Still haven't done the chunking itself, but the initial results are already considerably better.

**Additional information**

--
