### PR TITLE
fix: Fixed the design of the Notifications Tab on Safari. 

### DIFF
--- a/changelog/pr1625.json
+++ b/changelog/pr1625.json
@@ -1,0 +1,9 @@
+{
+  "pr_number": 1625,
+  "changes": [
+    {
+      "change": "Fixes",
+      "description": "Fixed a bug where the header wasn't properly hidden behind the modal box when the notifications tab was opened (on Safari only, due to the way Safari renders handles stacking contexts). This made it impossible to close the tab, as the close button was rendered below the header."
+    }
+  ]
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -62,13 +62,13 @@
 	</div>
 </header>
 
+<div *ngIf="showNotifications">
+	<app-notifications (NotificationsMode)="changeMode($event)"></app-notifications>
+</div>
+
 <!-- Container for the main element and the footer (to ensure they follow one another, rather than have fixed styling) -->
 <div id="contentContainer">
 	<main id="mainContent" role="main">
-		<div *ngIf="showNotifications">
-			<app-notifications
-							   (NotificationsMode)="changeMode($event)"></app-notifications>
-		</div>
 		<router-outlet></router-outlet>
 		<div id="alertContainer">
 			<app-alert></app-alert>

--- a/src/app/components/notifications/notifications.component.ts
+++ b/src/app/components/notifications/notifications.component.ts
@@ -76,9 +76,6 @@ export class NotificationsTab implements OnInit {
   */
   ngOnInit() {
     document.getElementById("exitButton")!.focus();
-    if (document.getElementById("siteHeader")) {
-      document.getElementById("siteHeader")!.className = "modal";
-    }
   }
 
   /*
@@ -191,9 +188,6 @@ export class NotificationsTab implements OnInit {
     modal!.removeEventListener("keydown", this.checkFocusBinded);
     if (document.getElementById("skipLink")) {
       document.getElementById("skipLink")!.focus();
-    }
-    if (document.getElementById("siteHeader")) {
-      document.getElementById("siteHeader")!.className = "";
     }
     this.NotificationsMode.emit(false);
   }

--- a/src/styles/headers.less
+++ b/src/styles/headers.less
@@ -24,7 +24,7 @@
   position: fixed;
   left: -10px;
   top: 0;
-  z-index: 100;
+  z-index: 10;
   background: @boxesBackground;
   align-items: center;
   justify-content: center;
@@ -69,7 +69,7 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 100;
+  z-index: 10;
   /* Responsive styling for screens up to 650px width */
   @media screen and (max-width: 650px) {
     padding-top: 2%;
@@ -472,7 +472,7 @@ app-header-message {
   width: 90%;
   margin: 0 5%;
   text-align: center;
-  z-index: 200;
+  z-index: 20;
   height: 20px;
 }
 

--- a/src/styles/modals.less
+++ b/src/styles/modals.less
@@ -16,7 +16,7 @@
   right: 0;
   margin-right: 15%;
   margin-left: 15%;
-  z-index: 100;
+  z-index: 30;
   background: @boxesBackground;
   /* Responsive design for screens above 500px width */
   @media screen and (min-width: 700px) {
@@ -65,7 +65,7 @@
   position: fixed;
   left: 0;
   top: 0;
-  z-index: 10;
+  z-index: 20;
 }
 
 /* Edit popup */

--- a/src/styles/postLists.less
+++ b/src/styles/postLists.less
@@ -186,7 +186,7 @@ app-single-post {
   overflow-y: visible;
   position: relative;
   top: 50px;
-  z-index: 100;
+  z-index: 15;
   width: 100%;
   background: @itemBackground;
   align-items: center;

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -567,7 +567,7 @@ app-search-results h3 {
 /* =================== Notifications Tab Component Styling =================== */
 /* Notifications Component */
 app-notifications {
-  z-index: 200;
+  z-index: 25;
 }
 
 /* Notifications panel */


### PR DESCRIPTION
**Description**

Right now on Safari the site's header is rendered above the notifications tab and the modal box. This makes it impossible to close the notifications tab.

**Issue link**

--

**Expected behavior**

The notifications tab should be rendered above the header.

**Your solution**

Moved the notifications tab so it's in the same stacking context as the site's header. This allows us to also remove the unnecessary setting of the header's class. This was done previously to force the header to be rendered below the modal box and the notifications tab (as z-index values only matter within the same stacking context), but now that they're in the same context, we no longer need it.

**Additional information**

--
