### PR TITLE
chore: Removed the font awesome group from dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,6 @@ updates:
           - "@angular/*"
         exclude-patterns:
           - "@angular/fire"
-      font-awesome:
-        patterns:
-          - "@fortawesome/fontawesome-*"
-          - "@fortawesome/free-*"
       size-limit:
         patterns:
           - "size-limit"

--- a/changelog/pr1949.json
+++ b/changelog/pr1949.json
@@ -1,0 +1,9 @@
+{
+  "pr_number": 1949,
+  "changes": [
+    {
+      "change": "Chores",
+      "description": "Removed the font awesome group from dependabot's grouped updates, as it seems the group is the reason dependabot stopped opening pull requests to update these dependencies. This is likely due to an issue in updating all font awesome packages together, which doesn't seem to have been solved yet."
+    }
+  ]
+}


### PR DESCRIPTION
**Description**

We seem to not be getting font awesome updates from dependabot, presumably because for some reason it seems the packages can't be updated together (as the single-package updates worked fine before).

**Your solution**

I removed the font awesome group from the dependabot config.